### PR TITLE
Fix/initial state trans

### DIFF
--- a/consensus/src/main/java/org/ethereum/beacon/consensus/state/ValidatorRegistryReader.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/state/ValidatorRegistryReader.java
@@ -1,5 +1,7 @@
 package org.ethereum.beacon.consensus.state;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.ethereum.beacon.core.BeaconState;
 import org.ethereum.beacon.core.spec.ChainSpec;
@@ -57,6 +59,18 @@ public interface ValidatorRegistryReader {
    * @return a size.
    */
   UInt24 size();
+
+  /**
+   * Returns all validator records
+   */
+  default List<ValidatorRecord> getAll() {
+    int size = size().getValue();
+    List<ValidatorRecord> ret = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      ret.add(get(UInt24.valueOf(i)));
+    }
+    return ret;
+  }
 
   /**
    * Returns validator record that public key is equal to given one.

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
@@ -65,7 +65,7 @@ public class SpecHelpersTest {
     }
 
     SpecHelpers specHelpers = new SpecHelpers(null);
-    ShardCommittee[][] shuffling = specHelpers.get_shuffling(
+    ShardCommittee[][] shuffling = specHelpers.get_active_shuffling(
         Hash32.fromHexString("0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d"),
         activeValidatorIndices.stream().mapToInt(i -> i).toArray(),
         210

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/NextSlotTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/NextSlotTransitionTest.java
@@ -14,6 +14,7 @@ import tech.pegasys.artemis.util.bytes.Bytes48;
 import tech.pegasys.artemis.util.bytes.Bytes96;
 import tech.pegasys.artemis.util.uint.UInt64;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -29,11 +30,16 @@ public class NextSlotTransitionTest {
     Hash32 receiptRoot = Hash32.random(rnd);
     ChainSpec chainSpec = ChainSpec.DEFAULT;
 
-    Deposit deposit = new Deposit(new Hash32[]{Hash32.random(rnd)}, UInt64.ZERO,
-        new DepositData(
-            new DepositInput(
-                Bytes48.ZERO, Hash32.ZERO, Hash32.ZERO, Hash32.ZERO, Bytes96.ZERO
-            ), chainSpec.getMaxDeposit().toGWei(), UInt64.ZERO));
+    List<Deposit> deposits = new ArrayList<>();
+    for (int i = 0; i < 8000; i++) {
+      Deposit deposit = new Deposit(new Hash32[]{Hash32.random(rnd)}, UInt64.ZERO,
+          new DepositData(
+              new DepositInput(
+                  Bytes48.intToBytes48(i), Hash32.random(rnd), Hash32.ZERO, Hash32.ZERO, Bytes96.ZERO
+              ), chainSpec.getMaxDeposit().toGWei(), UInt64.ZERO));
+      deposits.add(deposit);
+    }
+
     InitialStateTransition initialStateTransition =
         new InitialStateTransition(
             new DepositContract() {
@@ -44,7 +50,7 @@ public class NextSlotTransitionTest {
 
               @Override
               public List<Deposit> getInitialDeposits() {
-                return Collections.singletonList(deposit);
+                return deposits;
               }
             }, chainSpec);
 


### PR DESCRIPTION
Add initial shard_comittee to InitialStateTransition 

One thing I worry about here is that spec code is always mutating 'current state'. A mutation at some step may depend on some previous state change. Like in this code. 

With state builder it could be easy to miss this situation. May be we need to revisit the design? 