### PR TITLE
Feture/next slot

### DIFF
--- a/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
@@ -335,6 +335,27 @@ public class SpecHelpers {
             .getIntValue());
   }
 
+  /*
+    def merkle_root(values):
+    """
+    Merkleize ``values`` (where ``len(values)`` is a power of two) and return the Merkle root.
+    """
+    o = [0] * len(values) + values
+    for i in range(len(values) - 1, 0, -1):
+        o[i] = hash(o[i * 2] + o[i * 2 + 1])
+    return o[1]
+   */
+  public Hash32 merkle_root(List<? extends BytesValue> values) {
+    BytesValue[] o = new BytesValue[values.size() * 2];
+    for (int i = 0; i < values.size(); i++) {
+      o[i + values.size()] = values.get(i);
+    }
+    for (int i = values.size() - 1; i > 0; i--) {
+      o[i] = hash(BytesValue.wrap(o[i * 2], o[i * 2 + 1]));
+    }
+    return (Hash32) o[1];
+  }
+
   public Hash32 hash_tree_root(Object object) {
     return Hash32.ZERO;
   }

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/StateTransition.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/StateTransition.java
@@ -5,5 +5,5 @@ import org.ethereum.beacon.core.BeaconState;
 
 public interface StateTransition<S> {
 
-  BeaconState apply(BeaconBlock block, S state);
+  S apply(BeaconBlock block, S state);
 }

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/transition/BeaconStateEx.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/transition/BeaconStateEx.java
@@ -1,0 +1,30 @@
+package org.ethereum.beacon.consensus.transition;
+
+import org.ethereum.beacon.core.BeaconState;
+import tech.pegasys.artemis.ethereum.core.Hash32;
+
+/**
+ * Class to hold additional state info which is not included to the
+ * canonical spec BeaconState but is wanted for state transitions
+ */
+public class BeaconStateEx {
+  private final BeaconState canonicalState;
+  private final Hash32 latestChainBlock;
+
+  /**
+   * @param canonicalState regular BeaconState
+   * @param latestChainBlock  latest block which was processed on this state chain
+   */
+  public BeaconStateEx(BeaconState canonicalState, Hash32 latestChainBlock) {
+    this.canonicalState = canonicalState;
+    this.latestChainBlock = latestChainBlock;
+  }
+
+  public BeaconState getCanonicalState() {
+    return canonicalState;
+  }
+
+  public Hash32 getLatestChainBlockHash() {
+    return latestChainBlock;
+  }
+}

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/transition/InitialStateTransition.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/transition/InitialStateTransition.java
@@ -88,6 +88,7 @@ public class InitialStateTransition implements StateTransition<BeaconState> {
         .withPreviousEpochStartShard(chainSpec.getGenesisStartShard())
         .withCurrentEpochStartShard(chainSpec.getGenesisStartShard())
         .withPreviousEpochCalculationSlot(chainSpec.getGenesisSlot())
+        .withCurrentEpochCalculationSlot(chainSpec.getGenesisSlot())
         .withPreviousEpochRandaoMix(Hash32.ZERO)
         .withCurrentEpochRandaoMix(Hash32.ZERO);
 

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/InitialStateTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/InitialStateTransitionTest.java
@@ -39,7 +39,7 @@ public class InitialStateTransitionTest {
 
     BeaconState initialState =
         initialStateTransition.apply(
-            BeaconBlocks.createGenesis(ChainSpec.DEFAULT), BeaconState.getEmpty());
+            BeaconBlocks.createGenesis(ChainSpec.DEFAULT)).getCanonicalState();
 
     assertThat(initialState.getGenesisTime()).isEqualTo(genesisTime);
     assertThat(initialState.getLatestDepositRoot()).isEqualTo(receiptRoot);

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/NextSlotTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/NextSlotTransitionTest.java
@@ -53,12 +53,12 @@ public class NextSlotTransitionTest {
               }
             }, chainSpec);
 
-    BeaconState initialState =
-        initialStateTransition.apply(BeaconBlocks.createGenesis(chainSpec), BeaconState.getEmpty());
-    BeaconState s1State = new NextSlotTransition(chainSpec).apply(null, initialState);
-    BeaconState s2State = new NextSlotTransition(chainSpec).apply(null, s1State);
-    BeaconState s3State = new NextSlotTransition(chainSpec).apply(null, s2State);
+    BeaconStateEx initialState =
+        initialStateTransition.apply(BeaconBlocks.createGenesis(chainSpec));
+    BeaconStateEx s1State = new NextSlotTransition(chainSpec).apply(null, initialState);
+    BeaconStateEx s2State = new NextSlotTransition(chainSpec).apply(null, s1State);
+    BeaconStateEx s3State = new NextSlotTransition(chainSpec).apply(null, s2State);
 
-    Assert.assertEquals(UInt64.valueOf(3), s3State.getSlot());
+    Assert.assertEquals(UInt64.valueOf(3), s3State.getCanonicalState().getSlot());
   }
 }


### PR DESCRIPTION
Add `BeaconStateEx` wrapper to handle latest block for `state.latest_block_roots` modification. 
Since the block root for a slot state is added only on the next slot transition we need a way to keep the added block till the next transition. 
The general idea was to add this field to the `BeaconState` (without including to the hash calculation), it the intention is to keep the `BeaconState` canonical.
