### PR TITLE
Deposit verification

### DIFF
--- a/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/block/DepositListVerifier.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/block/DepositListVerifier.java
@@ -1,8 +1,13 @@
 package org.ethereum.beacon.consensus.verifier.block;
 
+import static org.ethereum.beacon.consensus.verifier.VerificationResult.PASSED;
+import static org.ethereum.beacon.consensus.verifier.VerificationResult.failedResult;
+
 import org.ethereum.beacon.consensus.verifier.OperationVerifier;
+import org.ethereum.beacon.consensus.verifier.VerificationResult;
 import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.spec.ChainSpec;
+import tech.pegasys.artemis.util.uint.UInt64;
 
 /**
  * Verifies deposit list.
@@ -13,6 +18,23 @@ public class DepositListVerifier extends OperationListVerifier<Deposit> {
 
   public DepositListVerifier(OperationVerifier<Deposit> operationVerifier, ChainSpec chainSpec) {
     super(operationVerifier, block -> block.getBody().getDeposits(), chainSpec.getMaxDeposits());
+
+    addCustomVerifier(
+        deposits -> {
+          if (deposits.size() > 0) {
+            UInt64 expectedIndex = deposits.get(0).getMerkleTreeIndex();
+            for (Deposit deposit : deposits) {
+              if (!deposit.getMerkleTreeIndex().equals(expectedIndex)) {
+                return failedResult(
+                    "inclusion order is broken, expected index %d but got %d",
+                    expectedIndex, deposit.getMerkleTreeIndex());
+              }
+              expectedIndex = expectedIndex.increment();
+            }
+          }
+
+          return PASSED;
+        });
   }
 
   @Override

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/DepositVerifier.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/DepositVerifier.java
@@ -1,0 +1,52 @@
+package org.ethereum.beacon.consensus.verifier.operation;
+
+import static org.ethereum.beacon.consensus.verifier.VerificationResult.PASSED;
+import static org.ethereum.beacon.consensus.verifier.VerificationResult.failedResult;
+
+import org.ethereum.beacon.consensus.SpecHelpers;
+import org.ethereum.beacon.consensus.verifier.OperationVerifier;
+import org.ethereum.beacon.consensus.verifier.VerificationResult;
+import org.ethereum.beacon.core.BeaconState;
+import org.ethereum.beacon.core.operations.Deposit;
+import org.ethereum.beacon.core.spec.ChainSpec;
+import tech.pegasys.artemis.ethereum.core.Hash32;
+import tech.pegasys.artemis.util.bytes.BytesValue;
+
+/**
+ * Verifies {@link Deposit} beacon chain operation.
+ *
+ * @see Deposit
+ * @see <a
+ *     href="https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#deposits-1">Deposits</a>
+ *     in the spec.
+ */
+public class DepositVerifier implements OperationVerifier<Deposit> {
+
+  private ChainSpec chainSpec;
+  private SpecHelpers specHelpers;
+
+  public DepositVerifier(ChainSpec chainSpec, SpecHelpers specHelpers) {
+    this.chainSpec = chainSpec;
+    this.specHelpers = specHelpers;
+  }
+
+  @Override
+  public VerificationResult verify(Deposit deposit, BeaconState state) {
+    BytesValue serializedDepositData =
+        specHelpers.serialized_deposit_data(deposit.getDepositData());
+    Hash32 serializedDataHash = specHelpers.hash(serializedDepositData);
+
+    if (!specHelpers.verify_merkle_branch(
+        serializedDataHash,
+        deposit.getMerkleBranch(),
+        chainSpec.getDepositContractTreeDepth(),
+        deposit.getMerkleTreeIndex(),
+        state.getLatestDepositRoot())) {
+
+      return failedResult(
+          "merkle proof verification failed, serialized_data_hash = %s", serializedDataHash);
+    }
+
+    return PASSED;
+  }
+}


### PR DESCRIPTION
### What's done
Implements deposit verification according to spec. Doesn't match block deposit entries with data pulled by contract, this is required to check order of deposits. Instead of contract interaction there is a verification of ascending indices order, indices are taken from block deposit entries. This part is either will be updated later or will be done on contract side by including deposit index into deposit's merkle proof. If later takes place current implementation will be sufficient to verify Deposit operation.

Resolves https://github.com/harmony-dev/beacon-chain-java/issues/24