### PR TITLE
Get rid of warnings in SSZ tests

### DIFF
--- a/ssz/src/test/java/org/ethereum/beacon/ssz/SSZHasherTest.java
+++ b/ssz/src/test/java/org/ethereum/beacon/ssz/SSZHasherTest.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import static com.sun.org.apache.xerces.internal.impl.dv.util.HexBin.decode;
 import static org.junit.Assert.assertEquals;
 
 /** Tests of {@link SSZHasher} */
@@ -41,7 +40,7 @@ public class SSZHasherTest {
 
   @Test
   public void bitfieldTest() {
-    Bitfield bitfield = new Bitfield(decode("abcd"));
+    Bitfield bitfield = new Bitfield(BytesValue.fromHexString("abcd").getArrayUnsafe());
 
     BytesValue hash = sszHasher.calc(bitfield);
     assertEquals(
@@ -66,7 +65,7 @@ public class SSZHasherTest {
             123,
             Collections.emptyList(),
             DEFAULT_HASH,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             DEFAULT_HASH,
             12412L,
             12400L,
@@ -90,7 +89,7 @@ public class SSZHasherTest {
             123,
             Collections.emptyList(),
             DEFAULT_HASH,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             DEFAULT_HASH,
             12412L,
             12400L,

--- a/ssz/src/test/java/org/ethereum/beacon/ssz/SSZSerializerTest.java
+++ b/ssz/src/test/java/org/ethereum/beacon/ssz/SSZSerializerTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.logging.Logger;
 import tech.pegasys.artemis.util.uint.UInt64;
 
-import static com.sun.org.apache.xerces.internal.impl.dv.util.HexBin.decode;
 import static net.consensys.cava.bytes.Bytes.fromHexString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -52,7 +51,7 @@ public class SSZSerializerTest {
 
   @Test
   public void bitfieldTest() {
-    Bitfield expected = new Bitfield(decode("abcd"));
+    Bitfield expected = new Bitfield(BytesValue.fromHexString("abcd").getArrayUnsafe());
 
     byte[] encoded = sszSerializer.encode(expected);
     Bitfield constructed = (Bitfield) sszSerializer.decode(encoded, Bitfield.class);
@@ -80,7 +79,7 @@ public class SSZSerializerTest {
             123,
             Collections.emptyList(),
             DEFAULT_HASH,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             DEFAULT_HASH,
             12412L,
             12400L,
@@ -108,7 +107,7 @@ public class SSZSerializerTest {
             123,
             Collections.emptyList(),
             DEFAULT_HASH,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             DEFAULT_HASH,
             12412L,
             12400L,
@@ -133,7 +132,7 @@ public class SSZSerializerTest {
             123,
             Collections.emptyList(),
             DEFAULT_HASH,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             DEFAULT_HASH,
             12412L,
             12400L,
@@ -177,7 +176,7 @@ public class SSZSerializerTest {
             123,
             Collections.emptyList(),
             null,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             null,
             12412L,
             12400L,
@@ -192,7 +191,7 @@ public class SSZSerializerTest {
             123,
             null,
             DEFAULT_HASH,
-            new Bitfield(decode("abcdef45")),
+            new Bitfield(BytesValue.fromHexString("abcdef45").getArrayUnsafe()),
             DEFAULT_HASH,
             12412L,
             12400L,

--- a/ssz/src/test/java/org/ethereum/beacon/ssz/fixtures/AttestationRecord.java
+++ b/ssz/src/test/java/org/ethereum/beacon/ssz/fixtures/AttestationRecord.java
@@ -5,8 +5,7 @@ import org.ethereum.beacon.ssz.annotation.SSZSerializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
-import static com.sun.org.apache.bcel.internal.classfile.Utility.toHexString;
+import tech.pegasys.artemis.util.bytes.BytesValue;
 
 /** Slot attestation data */
 @SSZSerializable
@@ -126,13 +125,13 @@ public class AttestationRecord {
             .append(obliqueParentHashes.size())
             .append(" item(s)]")
             .append(", shardBlockHash=")
-            .append(toHexString(shardBlockHash))
+            .append(BytesValue.wrap(shardBlockHash))
             .append(", attesterBitfield=")
             .append(attesterBitfield)
             .append(", justifiedSlot=")
             .append(justifiedSlot)
             .append(", justifiedBlockHash=")
-            .append(toHexString(justifiedBlockHash))
+            .append(BytesValue.wrap(justifiedBlockHash))
             .append(", aggregateSig=[")
             .append(aggregateSig)
             .append("}");


### PR DESCRIPTION
### What's done
Gets rid of warnings in SSZ tests by replacing Hex API from Sun to `BytesValue.fromHexString()`/`BytesValue.toString()`.