### PR TITLE
Get rid of Schedulers.get() statics

### DIFF
--- a/chain/src/main/java/org/ethereum/beacon/chain/DefaultBeaconChain.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/DefaultBeaconChain.java
@@ -38,11 +38,7 @@ public class DefaultBeaconChain implements MutableBeaconChain {
   private final BeaconTupleStorage tupleStorage;
 
   private final ReplayProcessor<BeaconTuple> blockSink = ReplayProcessor.cacheLast();
-  private final Publisher<BeaconTuple> blockStream =
-      Flux.from(blockSink)
-          .publishOn(Schedulers.get().reactorEvents())
-          .onBackpressureError()
-          .name("DefaultBeaconChain.block");
+  private final Publisher<BeaconTuple> blockStream;
 
   private BeaconTuple recentlyProcessed;
 
@@ -54,7 +50,8 @@ public class DefaultBeaconChain implements MutableBeaconChain {
       StateTransition<BeaconStateEx> perEpochTransition,
       BeaconBlockVerifier blockVerifier,
       BeaconStateVerifier stateVerifier,
-      BeaconChainStorage chainStorage) {
+      BeaconChainStorage chainStorage,
+      Schedulers schedulers) {
     this.specHelpers = specHelpers;
     this.initialTransition = initialTransition;
     this.perSlotTransition = perSlotTransition;
@@ -64,6 +61,11 @@ public class DefaultBeaconChain implements MutableBeaconChain {
     this.stateVerifier = stateVerifier;
     this.chainStorage = chainStorage;
     this.tupleStorage = chainStorage.getTupleStorage();
+
+    blockStream = Flux.from(blockSink)
+            .publishOn(schedulers.reactorEvents())
+            .onBackpressureError()
+            .name("DefaultBeaconChain.block");
   }
 
   @Override

--- a/chain/src/main/java/org/ethereum/beacon/chain/ProposedBlockProcessorImpl.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/ProposedBlockProcessorImpl.java
@@ -9,16 +9,16 @@ import reactor.core.publisher.Flux;
 public class ProposedBlockProcessorImpl implements ProposedBlockProcessor {
 
   private final DirectProcessor<BeaconBlock> blocksSink = DirectProcessor.create();
-  private final Publisher<BeaconBlock> blocksStream =
-      Flux.from(blocksSink)
-          .publishOn(Schedulers.get().reactorEvents())
-          .onBackpressureError()
-          .name("ProposedBlocksProcessor.blocks");
+  private final Publisher<BeaconBlock> blocksStream;
 
   private final MutableBeaconChain beaconChain;
 
-  public ProposedBlockProcessorImpl(MutableBeaconChain beaconChain) {
+  public ProposedBlockProcessorImpl(MutableBeaconChain beaconChain, Schedulers schedulers) {
     this.beaconChain = beaconChain;
+    blocksStream = Flux.from(blocksSink)
+            .publishOn(schedulers.reactorEvents())
+            .onBackpressureError()
+            .name("ProposedBlocksProcessor.blocks");
   }
 
   @Override

--- a/chain/src/test/java/org/ethereum/beacon/chain/DefaultBeaconChainTest.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/DefaultBeaconChainTest.java
@@ -17,10 +17,12 @@ import org.ethereum.beacon.consensus.verifier.VerificationResult;
 import org.ethereum.beacon.core.BeaconBlock;
 import org.ethereum.beacon.core.BeaconBlockBody;
 import org.ethereum.beacon.core.BeaconState;
+import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.state.Eth1Data;
 import org.ethereum.beacon.core.types.Time;
 import org.ethereum.beacon.db.Database;
 import org.ethereum.beacon.pow.DepositContract.ChainStart;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.junit.Assert;
 import org.junit.Test;
 import tech.pegasys.artemis.ethereum.core.Hash32;
@@ -30,7 +32,8 @@ public class DefaultBeaconChainTest {
 
   @Test
   public void insertAChain() {
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT,
+        System::currentTimeMillis);
     StateTransition<BeaconStateEx> perSlotTransition =
         StateTransitionTestUtil.createNextSlotTransition();
     MutableBeaconChain beaconChain = createBeaconChain(specHelpers, perSlotTransition);
@@ -97,6 +100,7 @@ public class DefaultBeaconChainTest {
         perEpochTransition,
         blockVerifier,
         stateVerifier,
-        chainStorage);
+        chainStorage,
+        Schedulers.get());
   }
 }

--- a/chain/src/test/java/org/ethereum/beacon/chain/DefaultBeaconChainTest.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/DefaultBeaconChainTest.java
@@ -22,6 +22,7 @@ import org.ethereum.beacon.core.state.Eth1Data;
 import org.ethereum.beacon.core.types.Time;
 import org.ethereum.beacon.db.Database;
 import org.ethereum.beacon.pow.DepositContract.ChainStart;
+import org.ethereum.beacon.schedulers.DefaultSchedulers;
 import org.ethereum.beacon.schedulers.Schedulers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,11 +33,12 @@ public class DefaultBeaconChainTest {
 
   @Test
   public void insertAChain() {
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT,
-        System::currentTimeMillis);
+    Schedulers schedulers = new DefaultSchedulers();
+
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime);
     StateTransition<BeaconStateEx> perSlotTransition =
         StateTransitionTestUtil.createNextSlotTransition();
-    MutableBeaconChain beaconChain = createBeaconChain(specHelpers, perSlotTransition);
+    MutableBeaconChain beaconChain = createBeaconChain(specHelpers, perSlotTransition, schedulers);
 
     beaconChain.init();
     BeaconTuple initialTuple = beaconChain.getRecentlyProcessed();
@@ -78,8 +80,8 @@ public class DefaultBeaconChainTest {
   }
 
   private MutableBeaconChain createBeaconChain(
-      SpecHelpers specHelpers, StateTransition<BeaconStateEx> perSlotTransition) {
-    Time start = Time.castFrom(UInt64.valueOf(System.currentTimeMillis() / 1000));
+      SpecHelpers specHelpers, StateTransition<BeaconStateEx> perSlotTransition, Schedulers schedulers) {
+    Time start = Time.castFrom(UInt64.valueOf(schedulers.getCurrentTime() / 1000));
     ChainStart chainStart = new ChainStart(start, Eth1Data.EMPTY, Collections.emptyList());
     BlockTransition<BeaconStateEx> initialTransition =
         new InitialStateTransition(chainStart, specHelpers);
@@ -101,6 +103,6 @@ public class DefaultBeaconChainTest {
         blockVerifier,
         stateVerifier,
         chainStorage,
-        Schedulers.get());
+        schedulers);
   }
 }

--- a/chain/src/test/java/org/ethereum/beacon/chain/DefaultBeaconChainTest.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/DefaultBeaconChainTest.java
@@ -33,7 +33,7 @@ public class DefaultBeaconChainTest {
 
   @Test
   public void insertAChain() {
-    Schedulers schedulers = new DefaultSchedulers();
+    Schedulers schedulers = Schedulers.createDefault();
 
     SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime);
     StateTransition<BeaconStateEx> perSlotTransition =

--- a/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
@@ -7,7 +7,7 @@ import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.Time;
 import org.ethereum.beacon.schedulers.ControlledSchedulers;
-import org.ethereum.beacon.schedulers.DefaultSchedulers;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import java.util.concurrent.CountDownLatch;
@@ -24,7 +24,7 @@ public class SlotTickerTests {
   SlotNumber previousTick = SlotNumber.ZERO;
 
   public SlotTickerTests() throws InterruptedException {
-    schedulers = new ControlledSchedulers();
+    schedulers = Schedulers.createControlled();
     MutableBeaconState beaconState = BeaconState.getEmpty().createMutableCopy();
     while (schedulers.getCurrentTime() % MILLIS_IN_SECOND < 100
         || schedulers.getCurrentTime() % MILLIS_IN_SECOND > 900) {
@@ -46,7 +46,7 @@ public class SlotTickerTests {
         };
     SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, schedulers::getCurrentTime);
     genesisSlot = specHelpers.getChainSpec().getGenesisSlot();
-    slotTicker = new SlotTicker(specHelpers, beaconState, new DefaultSchedulers());
+    slotTicker = new SlotTicker(specHelpers, beaconState, Schedulers.createDefault());
   }
 
   @Test

--- a/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
@@ -6,6 +6,7 @@ import org.ethereum.beacon.core.MutableBeaconState;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.Time;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import java.util.concurrent.CountDownLatch;
@@ -41,9 +42,9 @@ public class SlotTickerTests {
             return Time.of(1);
           }
         };
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec);
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, System::currentTimeMillis);
     genesisSlot = specHelpers.getChainSpec().getGenesisSlot();
-    slotTicker = new SlotTicker(specHelpers, beaconState);
+    slotTicker = new SlotTicker(specHelpers, beaconState, Schedulers.get());
   }
 
   @Test

--- a/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
@@ -18,13 +18,13 @@ import static org.junit.Assert.assertTrue;
 
 public class SlotTickerTests {
   public static final int MILLIS_IN_SECOND = 1000;
-  private final ControlledSchedulers schedulers;
+  private final Schedulers schedulers;
   SlotTicker slotTicker;
   SlotNumber genesisSlot;
   SlotNumber previousTick = SlotNumber.ZERO;
 
   public SlotTickerTests() throws InterruptedException {
-    schedulers = Schedulers.createControlled();
+    schedulers = Schedulers.createDefault();
     MutableBeaconState beaconState = BeaconState.getEmpty().createMutableCopy();
     while (schedulers.getCurrentTime() % MILLIS_IN_SECOND < 100
         || schedulers.getCurrentTime() % MILLIS_IN_SECOND > 900) {

--- a/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/SlotTickerTests.java
@@ -6,30 +6,32 @@ import org.ethereum.beacon.core.MutableBeaconState;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.Time;
-import org.ethereum.beacon.schedulers.Schedulers;
+import org.ethereum.beacon.schedulers.ControlledSchedulers;
+import org.ethereum.beacon.schedulers.DefaultSchedulers;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SlotTickerTests {
   public static final int MILLIS_IN_SECOND = 1000;
+  private final ControlledSchedulers schedulers;
   SlotTicker slotTicker;
   SlotNumber genesisSlot;
   SlotNumber previousTick = SlotNumber.ZERO;
 
   public SlotTickerTests() throws InterruptedException {
+    schedulers = new ControlledSchedulers();
     MutableBeaconState beaconState = BeaconState.getEmpty().createMutableCopy();
-    while (System.currentTimeMillis() % MILLIS_IN_SECOND < 100
-        || System.currentTimeMillis() % MILLIS_IN_SECOND > 900) {
+    while (schedulers.getCurrentTime() % MILLIS_IN_SECOND < 100
+        || schedulers.getCurrentTime() % MILLIS_IN_SECOND > 900) {
       Thread.sleep(100);
     }
     beaconState.setGenesisTime(
-        Time.of(System.currentTimeMillis() / MILLIS_IN_SECOND).minus(Time.of(2)));
+        Time.of(schedulers.getCurrentTime() / MILLIS_IN_SECOND).minus(Time.of(2)));
     ChainSpec chainSpec =
         new ChainSpec() {
           @Override
@@ -42,9 +44,9 @@ public class SlotTickerTests {
             return Time.of(1);
           }
         };
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, System::currentTimeMillis);
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, schedulers::getCurrentTime);
     genesisSlot = specHelpers.getChainSpec().getGenesisSlot();
-    slotTicker = new SlotTicker(specHelpers, beaconState, Schedulers.get());
+    slotTicker = new SlotTicker(specHelpers, beaconState, new DefaultSchedulers());
   }
 
   @Test

--- a/chain/src/test/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorTest.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorTest.java
@@ -6,36 +6,22 @@ import java.util.List;
 import org.ethereum.beacon.chain.util.SampleObservableState;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.schedulers.ControlledSchedulers;
-import org.ethereum.beacon.schedulers.Schedulers;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 
 public class ObservableStateProcessorTest {
 
-  static ControlledSchedulers schedulers = new ControlledSchedulers();
-
-  @BeforeClass
-  public static void init() {
-    Schedulers.set(schedulers);
-  }
-
-  @AfterClass
-  public static void cleanup() {
-    Schedulers.resetToDefault();
-  }
-
   @Test
   public void test1() throws Exception {
+    ControlledSchedulers schedulers = new ControlledSchedulers();
     Duration genesisTime = Duration.ofMinutes(10);
     SlotNumber genesisSlot = SlotNumber.of(1_000_000);
     schedulers.setCurrentTime((genesisTime.getSeconds() + 1) * 1000);
 
     SampleObservableState sample = new SampleObservableState(
         genesisTime, genesisSlot.getValue(), Duration.ofSeconds(10), 8, s -> {
-    });
+    }, schedulers);
 
     List<ObservableBeaconState> states = new ArrayList<>();
     Flux.from(sample.observableStateProcessor.getObservableStateStream()).subscribe(states::add);
@@ -63,13 +49,14 @@ public class ObservableStateProcessorTest {
 
   @Test
   public void test2() throws Exception {
+    ControlledSchedulers schedulers = new ControlledSchedulers();
     Duration genesisTime = Duration.ofMinutes(10);
     SlotNumber genesisSlot = SlotNumber.of(1_000_000);
     schedulers.setCurrentTime(genesisTime.plus(Duration.ofMinutes(10)).toMillis());
 
     SampleObservableState sample = new SampleObservableState(
         genesisTime, genesisSlot.getValue(), Duration.ofSeconds(10), 8, s -> {
-    });
+    }, schedulers);
 
     List<ObservableBeaconState> states = new ArrayList<>();
     Flux.from(sample.observableStateProcessor.getObservableStateStream()).subscribe(s -> states.add(s));

--- a/chain/src/test/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorTest.java
+++ b/chain/src/test/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.ethereum.beacon.chain.util.SampleObservableState;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.schedulers.ControlledSchedulers;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
@@ -14,7 +15,7 @@ public class ObservableStateProcessorTest {
 
   @Test
   public void test1() throws Exception {
-    ControlledSchedulers schedulers = new ControlledSchedulers();
+    ControlledSchedulers schedulers = Schedulers.createControlled();
     Duration genesisTime = Duration.ofMinutes(10);
     SlotNumber genesisSlot = SlotNumber.of(1_000_000);
     schedulers.setCurrentTime((genesisTime.getSeconds() + 1) * 1000);
@@ -49,7 +50,7 @@ public class ObservableStateProcessorTest {
 
   @Test
   public void test2() throws Exception {
-    ControlledSchedulers schedulers = new ControlledSchedulers();
+    ControlledSchedulers schedulers = Schedulers.createControlled();
     Duration genesisTime = Duration.ofMinutes(10);
     SlotNumber genesisSlot = SlotNumber.of(1_000_000);
     schedulers.setCurrentTime(genesisTime.plus(Duration.ofMinutes(10)).toMillis());

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
@@ -65,6 +66,7 @@ public class SpecHelpers {
   private final ChainSpec spec;
   private final ObjectHasher<Hash32> objectHasher;
   private final Function<BytesValue, Hash32> hashFunction;
+  private final Supplier<Long> systemTimeSupplier;
 
   /**
    * Creates a SpecHelpers instance with {@link ChainSpec#DEFAULT} as a chain spec, {@link
@@ -77,6 +79,14 @@ public class SpecHelpers {
     return createWithSSZHasher(ChainSpec.DEFAULT);
   }
 
+  public static SpecHelpers createWithSSZHasher(@Nonnull ChainSpec spec) {
+    return createWithSSZHasher(
+        spec,
+        () -> {
+          throw new RuntimeException("Time supplier required");
+        });
+  }
+
   /**
    * Creates a SpecHelpers instance with given {@link ChainSpec}, {@link
    * Hashes#keccak256(BytesValue)} as a hash function and {@link SSZObjectHasher} as an object
@@ -85,21 +95,22 @@ public class SpecHelpers {
    * @param spec a chain spec.
    * @return spec helpers instance.
    */
-  public static SpecHelpers createWithSSZHasher(@Nonnull ChainSpec spec) {
+  public static SpecHelpers createWithSSZHasher(@Nonnull ChainSpec spec, @Nonnull Supplier<Long> systemTimeSupplier) {
     Objects.requireNonNull(spec);
 
     Function<BytesValue, Hash32> hashFunction = Hashes::keccak256;
     ObjectHasher<Hash32> sszHasher = SSZObjectHasher.create(hashFunction);
-    return new SpecHelpers(spec, hashFunction, sszHasher);
+    return new SpecHelpers(spec, hashFunction, sszHasher, systemTimeSupplier);
   }
 
-  public SpecHelpers(
-      ChainSpec spec,
+  public SpecHelpers(ChainSpec spec,
       Function<BytesValue, Hash32> hashFunction,
-      ObjectHasher<Hash32> objectHasher) {
+      ObjectHasher<Hash32> objectHasher,
+      Supplier<Long> systemTimeSupplier) {
     this.spec = spec;
-    this.hashFunction = hashFunction;
     this.objectHasher = objectHasher;
+    this.hashFunction = hashFunction;
+    this.systemTimeSupplier = systemTimeSupplier;
   }
 
   public ChainSpec getChainSpec() {
@@ -1385,7 +1396,7 @@ public class SpecHelpers {
   }
 
   public SlotNumber get_current_slot(BeaconState state) {
-    Millis currentTime = Millis.of(Schedulers.get().getCurrentTime());
+    Millis currentTime = Millis.of(systemTimeSupplier.get());
     assertTrue(state.getGenesisTime().lessEqual(currentTime.getSeconds()));
     Time sinceGenesis = currentTime.getSeconds().minus(state.getGenesisTime());
     return SlotNumber.castFrom(sinceGenesis.dividedBy(spec.getSlotDuration()))

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
@@ -69,30 +69,13 @@ public class SpecHelpers {
   private final Supplier<Long> systemTimeSupplier;
 
   /**
-   * Creates a SpecHelpers instance with {@link ChainSpec#DEFAULT} as a chain spec, {@link
-   * Hashes#keccak256(BytesValue)} as a hash function and {@link SSZObjectHasher} as an object
-   * hasher.
-   *
-   * @return spec helpers instance.
-   */
-  public static SpecHelpers createDefault() {
-    return createWithSSZHasher(ChainSpec.DEFAULT);
-  }
-
-  public static SpecHelpers createWithSSZHasher(@Nonnull ChainSpec spec) {
-    return createWithSSZHasher(
-        spec,
-        () -> {
-          throw new RuntimeException("Time supplier required");
-        });
-  }
-
-  /**
-   * Creates a SpecHelpers instance with given {@link ChainSpec}, {@link
-   * Hashes#keccak256(BytesValue)} as a hash function and {@link SSZObjectHasher} as an object
+   * Creates a SpecHelpers instance with given {@link ChainSpec} and time supplier,
+   * {@link Hashes#keccak256(BytesValue)} as a hash function and {@link SSZObjectHasher} as an object
    * hasher.
    *
    * @param spec a chain spec.
+   * @param systemTimeSupplier The current system time supplier. Normally the
+   *    <code>Schedulers::currentTime</code> is passed
    * @return spec helpers instance.
    */
   public static SpecHelpers createWithSSZHasher(@Nonnull ChainSpec spec, @Nonnull Supplier<Long> systemTimeSupplier) {

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/transition/PerSlotTransition.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/transition/PerSlotTransition.java
@@ -18,19 +18,16 @@ import org.ethereum.beacon.core.types.SlotNumber;
 public class PerSlotTransition implements StateTransition<BeaconStateEx> {
   private static final Logger logger = LogManager.getLogger(PerSlotTransition.class);
 
+  private final SpecHelpers specHelpers;
   private final ChainSpec spec;
 
   public PerSlotTransition(SpecHelpers specHelpers) {
-    this(specHelpers.getChainSpec());
-  }
-
-  public PerSlotTransition(ChainSpec spec) {
-    this.spec = spec;
+    this.specHelpers = specHelpers;
+    this.spec = specHelpers.getChainSpec();
   }
 
   @Override
   public BeaconStateEx apply(BeaconStateEx stateEx) {
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(spec);
 
     MutableBeaconState state = stateEx.getCanonicalState().createMutableCopy();
 

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
@@ -1,6 +1,7 @@
 package org.ethereum.beacon.consensus;
 
 import org.ethereum.beacon.core.operations.deposit.DepositInput;
+import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.crypto.Hashes;
@@ -23,7 +24,7 @@ public class SpecHelpersTest {
 
   @Test
   public void shuffleTest0() throws Exception {
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
 
     int[] sample = new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
@@ -68,7 +69,7 @@ public class SpecHelpersTest {
       }
     }
 
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
 
     Map<Integer, Long> map = Arrays.stream(statuses).boxed().collect
         (Collectors.groupingBy(Function.identity(), Collectors.counting()));
@@ -89,7 +90,7 @@ public class SpecHelpersTest {
 
   @Test
   public void testHashTreeRoot1() {
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     Hash32 expected =
         Hash32.fromHexString("0x8fc89d0f1f435b07543b15fdf687e7fce4a754ecd9e5afbf8f0e83928a7f798f");
     Hash32 actual = specHelpers.hash_tree_root(createDepositInput());

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/InitialStateTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/InitialStateTransitionTest.java
@@ -23,10 +23,11 @@ public class InitialStateTransitionTest {
     Time genesisTime = Time.castFrom(UInt64.random(rnd));
     Eth1Data eth1Data = new Eth1Data(Hash32.random(rnd), Hash32.random(rnd));
 
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     InitialStateTransition initialStateTransition =
         new InitialStateTransition(
             new ChainStart(genesisTime, eth1Data, Collections.emptyList()),
-            SpecHelpers.createDefault());
+            specHelpers);
 
     BeaconState initialState =
         initialStateTransition.apply(

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerEpochTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerEpochTransitionTest.java
@@ -33,7 +33,7 @@ public class PerEpochTransitionTest {
           }
         };
 
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec);
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, () -> 0L);
 
     List<Deposit> deposits = TestUtils.getAnyDeposits(specHelpers, 8).getValue0();
 

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerEpochTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerEpochTransitionTest.java
@@ -44,7 +44,7 @@ public class PerEpochTransitionTest {
 
     states[0] = initialStateTransition.apply(BeaconBlocks.createGenesis(chainSpec));
     for (int i = 1; i < 9; i++) {
-      states[i] = new PerSlotTransition(chainSpec).apply(states[i - 1]);
+      states[i] = new PerSlotTransition(specHelpers).apply(states[i - 1]);
     }
     PerEpochTransition perEpochTransition = new PerEpochTransition(specHelpers);
     BeaconStateEx epochState = perEpochTransition.apply(states[8]);

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerSlotTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerSlotTransitionTest.java
@@ -30,7 +30,7 @@ public class PerSlotTransitionTest {
             return new SlotNumber.EpochLength(UInt64.valueOf(8));
           }
         };
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec);
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, () -> 0L);
 
     List<Deposit> deposits = TestUtils.getAnyDeposits(specHelpers, 8).getValue0();
 

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerSlotTransitionTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/transition/PerSlotTransitionTest.java
@@ -41,9 +41,9 @@ public class PerSlotTransitionTest {
 
     BeaconStateEx initialState =
         initialStateTransition.apply(BeaconBlocks.createGenesis(chainSpec));
-    BeaconStateEx s1State = new PerSlotTransition(chainSpec).apply(initialState);
-    BeaconStateEx s2State = new PerSlotTransition(chainSpec).apply(s1State);
-    BeaconStateEx s3State = new PerSlotTransition(chainSpec).apply(s2State);
+    BeaconStateEx s1State = new PerSlotTransition(specHelpers).apply(initialState);
+    BeaconStateEx s2State = new PerSlotTransition(specHelpers).apply(s1State);
+    BeaconStateEx s3State = new PerSlotTransition(specHelpers).apply(s2State);
 
     Assert.assertEquals(chainSpec.getGenesisSlot().plus(3), s3State.getCanonicalState().getSlot());
   }

--- a/pow/core/src/main/java/org/ethereum/beacon/pow/AbstractDepositContract.java
+++ b/pow/core/src/main/java/org/ethereum/beacon/pow/AbstractDepositContract.java
@@ -25,29 +25,6 @@ import tech.pegasys.artemis.util.bytes.BytesValue;
 import tech.pegasys.artemis.util.uint.UInt64;
 
 public abstract class AbstractDepositContract implements DepositContract {
-
-  private final Serializer ssz = Serializer.annotationSerializer();
-
-  private long distanceFromHead;
-
-  private final MonoProcessor<ChainStart> chainStartSink = MonoProcessor.create();
-  private final Publisher<ChainStart> chainStartStream = chainStartSink
-      .publishOn(Schedulers.get().reactorEvents())
-      .doOnSubscribe(s -> chainStartSubscribedPriv())
-      .name("PowClient.chainStart");
-
-  private final ReplayProcessor<Deposit> depositSink =
-      ReplayProcessor.cacheLast();
-  private final Publisher<Deposit> depositStream =
-      Flux.from(depositSink)
-          .publishOn(Schedulers.get().reactorEvents())
-          .onBackpressureError()
-          .name("PowClient.deposit");
-
-  private List<Deposit> initialDeposits = new ArrayList<>();
-  private boolean startChainSubscribed;
-
-
   protected class DepositEventData {
     public final byte[] deposit_root;
     public final byte[] data;
@@ -61,6 +38,33 @@ public abstract class AbstractDepositContract implements DepositContract {
       this.merkle_tree_index = merkle_tree_index;
       this.merkle_branch = merkle_branch;
     }
+  }
+
+  private final Serializer ssz = Serializer.annotationSerializer();
+
+  private long distanceFromHead;
+
+  protected final Schedulers schedulers;
+  private final MonoProcessor<ChainStart> chainStartSink = MonoProcessor.create();
+  private final Publisher<ChainStart> chainStartStream;
+
+  private final ReplayProcessor<Deposit> depositSink = ReplayProcessor.cacheLast();
+  private final Publisher<Deposit> depositStream;
+
+  private List<Deposit> initialDeposits = new ArrayList<>();
+  private boolean startChainSubscribed;
+
+  public AbstractDepositContract(Schedulers schedulers) {
+    this.schedulers = schedulers;
+
+    chainStartStream = chainStartSink
+        .publishOn(this.schedulers.reactorEvents())
+        .doOnSubscribe(s -> chainStartSubscribedPriv())
+        .name("PowClient.chainStart");
+    depositStream = Flux.from(depositSink)
+            .publishOn(this.schedulers.reactorEvents())
+            .onBackpressureError()
+            .name("PowClient.deposit");
   }
 
   protected synchronized void newDeposit(DepositEventData eventData, byte[] blockHash) {

--- a/pow/ethereumj/src/main/java/org/ethereum/beacon/pow/EthereumJDepositContract.java
+++ b/pow/ethereumj/src/main/java/org/ethereum/beacon/pow/EthereumJDepositContract.java
@@ -33,7 +33,7 @@ public class EthereumJDepositContract extends AbstractDepositContract {
   private static final String DEPOSIT_EVENT_NAME = "Deposit";
   private static final String CHAIN_START_EVENT_NAME = "ChainStart";
 
-  private final Scheduler blockExecutor = Schedulers.get().blocking();
+  private final Scheduler blockExecutor;
 
   private final Ethereum ethereum;
   private final Address contractDeployAddress;
@@ -47,7 +47,8 @@ public class EthereumJDepositContract extends AbstractDepositContract {
   private boolean chainStartComplete;
 
   public EthereumJDepositContract(Ethereum ethereum, long contractDeployBlock,
-      String contractDeployAddress) {
+      String contractDeployAddress, Schedulers schedulers) {
+    super(schedulers);
     this.ethereum = ethereum;
     this.contractDeployAddress = Address.fromHexString(contractDeployAddress);
     contractDeployAddressHash =
@@ -56,6 +57,7 @@ public class EthereumJDepositContract extends AbstractDepositContract {
     this.contract = new Contract(ContractAbi.getContractAbi());
     this.contractDeployBlock = contractDeployBlock;
     processedUpToBlock = contractDeployBlock;
+    blockExecutor = this.schedulers.blocking();
   }
 
   @Override

--- a/pow/ethereumj/src/test/java/org/ethereum/beacon/pow/StandaloneDepositContractTest.java
+++ b/pow/ethereumj/src/test/java/org/ethereum/beacon/pow/StandaloneDepositContractTest.java
@@ -13,6 +13,7 @@ import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.pow.DepositContract.ChainStart;
 import org.ethereum.beacon.pow.DepositContract.DepositInfo;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.ssz.Serializer;
 import org.ethereum.config.SystemProperties;
 import org.ethereum.facade.Ethereum;
@@ -80,7 +81,7 @@ public class StandaloneDepositContractTest {
 
     Ethereum ethereum = new StandaloneEthereum(new SystemProperties(), sb);
     EthereumJDepositContract depositContract = new EthereumJDepositContract(
-        ethereum, 0, BytesValue.wrap(contract.getAddress()).toString());
+        ethereum, 0, BytesValue.wrap(contract.getAddress()).toString(), Schedulers.get());
     depositContract.setDistanceFromHead(3);
 
     ChainStart chainStart = Mono.from(depositContract.getChainStartMono())
@@ -136,7 +137,7 @@ public class StandaloneDepositContractTest {
 
     Ethereum ethereum = new StandaloneEthereum(new SystemProperties(), sb);
     EthereumJDepositContract depositContract = new EthereumJDepositContract(
-        ethereum, 0, BytesValue.wrap(contract.getAddress()).toString());
+        ethereum, 0, BytesValue.wrap(contract.getAddress()).toString(), Schedulers.get());
     depositContract.setDistanceFromHead(3);
     Mono<ChainStart> chainStartMono = Mono.from(depositContract.getChainStartMono());
     chainStartMono.subscribe();

--- a/pow/ethereumj/src/test/java/org/ethereum/beacon/pow/StandaloneDepositContractTest.java
+++ b/pow/ethereumj/src/test/java/org/ethereum/beacon/pow/StandaloneDepositContractTest.java
@@ -86,7 +86,7 @@ public class StandaloneDepositContractTest {
             ethereum,
             0,
             BytesValue.wrap(contract.getAddress()).toString(),
-            new DefaultSchedulers());
+            Schedulers.createDefault());
     depositContract.setDistanceFromHead(3);
 
     ChainStart chainStart = Mono.from(depositContract.getChainStartMono())
@@ -146,7 +146,7 @@ public class StandaloneDepositContractTest {
             ethereum,
             0,
             BytesValue.wrap(contract.getAddress()).toString(),
-            new DefaultSchedulers());
+            Schedulers.createDefault());
     depositContract.setDistanceFromHead(3);
     Mono<ChainStart> chainStartMono = Mono.from(depositContract.getChainStartMono());
     chainStartMono.subscribe();

--- a/pow/ethereumj/src/test/java/org/ethereum/beacon/pow/StandaloneDepositContractTest.java
+++ b/pow/ethereumj/src/test/java/org/ethereum/beacon/pow/StandaloneDepositContractTest.java
@@ -13,6 +13,7 @@ import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.pow.DepositContract.ChainStart;
 import org.ethereum.beacon.pow.DepositContract.DepositInfo;
+import org.ethereum.beacon.schedulers.DefaultSchedulers;
 import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.ssz.Serializer;
 import org.ethereum.config.SystemProperties;
@@ -80,8 +81,12 @@ public class StandaloneDepositContractTest {
     }
 
     Ethereum ethereum = new StandaloneEthereum(new SystemProperties(), sb);
-    EthereumJDepositContract depositContract = new EthereumJDepositContract(
-        ethereum, 0, BytesValue.wrap(contract.getAddress()).toString(), Schedulers.get());
+    EthereumJDepositContract depositContract =
+        new EthereumJDepositContract(
+            ethereum,
+            0,
+            BytesValue.wrap(contract.getAddress()).toString(),
+            new DefaultSchedulers());
     depositContract.setDistanceFromHead(3);
 
     ChainStart chainStart = Mono.from(depositContract.getChainStartMono())
@@ -136,8 +141,12 @@ public class StandaloneDepositContractTest {
     sb.createBlock();
 
     Ethereum ethereum = new StandaloneEthereum(new SystemProperties(), sb);
-    EthereumJDepositContract depositContract = new EthereumJDepositContract(
-        ethereum, 0, BytesValue.wrap(contract.getAddress()).toString(), Schedulers.get());
+    EthereumJDepositContract depositContract =
+        new EthereumJDepositContract(
+            ethereum,
+            0,
+            BytesValue.wrap(contract.getAddress()).toString(),
+            new DefaultSchedulers());
     depositContract.setDistanceFromHead(3);
     Mono<ChainStart> chainStartMono = Mono.from(depositContract.getChainStartMono());
     chainStartMono.subscribe();

--- a/pow/validator/build.gradle
+++ b/pow/validator/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation project(':chain')
   implementation project(':consensus')
   implementation project(':validator')
+  implementation project(':util')
   implementation project(':db:core')
 
   implementation 'io.projectreactor:reactor-core'

--- a/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationServiceImpl.java
+++ b/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationServiceImpl.java
@@ -17,6 +17,7 @@ import org.ethereum.beacon.core.types.EpochNumber;
 import org.ethereum.beacon.core.types.Gwei;
 import org.ethereum.beacon.db.source.SingleValueSource;
 import org.ethereum.beacon.pow.DepositContract;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.ssz.Serializer;
 import org.ethereum.beacon.validator.BeaconChainAttester;
 import org.ethereum.beacon.validator.BeaconChainProposer;
@@ -48,6 +49,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
   private final DepositContract depositContract;
   private final Publisher<ObservableBeaconState> observablePublisher;
   private final SingleValueSource<RegistrationStage> stagePersistence;
+  private final Schedulers schedulers;
 
   private final SpecHelpers specHelpers;
   private final Serializer sszSerializer;
@@ -73,13 +75,15 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
       DepositContract depositContract,
       Publisher<ObservableBeaconState> observablePublisher,
       SingleValueSource<RegistrationStage> registrationStagePersistence,
-      SpecHelpers specHelpers) {
+      SpecHelpers specHelpers,
+      Schedulers schedulers) {
     this.transactionBuilder = transactionBuilder;
     this.transactionGateway = transactionGateway;
     this.depositContract = depositContract;
     this.observablePublisher = observablePublisher;
     this.stagePersistence = registrationStagePersistence;
     this.specHelpers = specHelpers;
+    this.schedulers = schedulers;
     sszSerializer = Serializer.annotationSerializer();
   }
 
@@ -205,7 +209,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
           new BeaconChainAttesterImpl(specHelpers, specHelpers.getChainSpec());
       validatorService =
           new BeaconChainValidator(
-              pubKey, proposer, attester, specHelpers, signer, observablePublisher);
+              pubKey, proposer, attester, specHelpers, signer, observablePublisher, schedulers);
       validatorService.start();
       changeCurrentStage(RegistrationStage.COMPLETE);
     }

--- a/start/common/src/main/java/org/ethereum/beacon/Launcher.java
+++ b/start/common/src/main/java/org/ethereum/beacon/Launcher.java
@@ -26,6 +26,7 @@ import org.ethereum.beacon.crypto.MessageParameters;
 import org.ethereum.beacon.db.InMemoryDatabase;
 import org.ethereum.beacon.pow.DepositContract;
 import org.ethereum.beacon.pow.DepositContract.ChainStart;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.validator.BeaconChainProposer;
 import org.ethereum.beacon.validator.BeaconChainValidator;
 import org.ethereum.beacon.validator.attester.BeaconChainAttesterImpl;
@@ -50,15 +51,22 @@ public class Launcher {
   BeaconChainAttesterImpl beaconChainAttester;
   BeaconChainValidator beaconChainValidator;
   BeaconChainStorageFactory storageFactory;
+  Schedulers schedulers;
 
-  public Launcher(SpecHelpers specHelpers, DepositContract depositContract,
-      KeyPair validatorSig, WireApi wireApi, BeaconChainStorageFactory storageFactory) {
+  public Launcher(
+      SpecHelpers specHelpers,
+      DepositContract depositContract,
+      KeyPair validatorSig,
+      WireApi wireApi,
+      BeaconChainStorageFactory storageFactory,
+      Schedulers schedulers) {
 
     this.specHelpers = specHelpers;
     this.depositContract = depositContract;
     this.validatorSig = validatorSig;
     this.wireApi = wireApi;
     this.storageFactory = storageFactory;
+    this.schedulers = schedulers;
 
     if (depositContract != null) {
       Mono.from(depositContract.getChainStartMono()).subscribe(this::chainStarted);
@@ -87,10 +95,12 @@ public class Launcher {
         perEpochTransition,
         blockVerifier,
         stateVerifier,
-        beaconChainStorage);
+        beaconChainStorage,
+        schedulers);
     beaconChain.init();
 
-    slotTicker = new SlotTicker(specHelpers, beaconChain.getRecentlyProcessed().getState());
+    slotTicker =
+        new SlotTicker(specHelpers, beaconChain.getRecentlyProcessed().getState(), schedulers);
     slotTicker.start();
 
     DirectProcessor<Attestation> allAttestations = DirectProcessor.create();
@@ -103,7 +113,8 @@ public class Launcher {
         beaconChain.getBlockStatesStream(),
         specHelpers,
         perSlotTransition,
-        perEpochTransition);
+        perEpochTransition,
+        schedulers);
     observableStateProcessor.start();
 
     beaconChainProposer = new BeaconChainProposerImpl(specHelpers,
@@ -118,11 +129,12 @@ public class Launcher {
         specHelpers,
         (msgHash, domain) -> BLSSignature.wrap(
             BLS381.sign(MessageParameters.create(msgHash, domain), validatorSig).getEncoded()),
-        observableStateProcessor.getObservableStateStream());
+        observableStateProcessor.getObservableStateStream(),
+        schedulers);
     beaconChainValidator.start();
 
     ProposedBlockProcessor proposedBlocksProcessor = new ProposedBlockProcessorImpl(
-        beaconChain);
+        beaconChain, schedulers);
     Flux.from(beaconChainValidator.getProposedBlocksStream())
         .subscribe(proposedBlocksProcessor::newBlockProposed);
     Flux.from(proposedBlocksProcessor.processedBlocksStream())

--- a/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
+++ b/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
@@ -71,7 +71,7 @@ public class LocalNetTest {
     int validatorCount = 4;
     int epochLength = 2;
 
-    ControlledSchedulers schedulers = new ControlledSchedulers();
+    ControlledSchedulers schedulers = Schedulers.createControlled();
 
     Random rnd = new Random(1);
     Time genesisTime = Time.of(10 * 60);

--- a/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
+++ b/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
@@ -104,7 +104,7 @@ public class LocalNetTest {
           }
         };
 
-    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec);
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(chainSpec, schedulers::getCurrentTime);
 
     Pair<List<Deposit>, List<KeyPair>> anyDeposits = TestUtils.getAnyDeposits(specHelpers, validatorCount);
     List<Deposit> deposits = anyDeposits.getValue0();

--- a/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
+++ b/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
@@ -72,7 +72,6 @@ public class LocalNetTest {
     int epochLength = 2;
 
     ControlledSchedulers schedulers = new ControlledSchedulers();
-    Schedulers.set(schedulers);
 
     Random rnd = new Random(1);
     Time genesisTime = Time.of(10 * 60);
@@ -118,7 +117,7 @@ public class LocalNetTest {
     for(int i = 0; i < validatorCount; i++) {
       WireApi wireApi = localWireHub.createNewPeer("" + i);
       Launcher launcher = new Launcher(specHelpers, depositContract, anyDeposits.getValue1().get(i),
-          wireApi, new MemBeaconChainStorageFactory());
+          wireApi, new MemBeaconChainStorageFactory(), schedulers);
 
       int finalI = i;
       Flux.from(launcher.slotTicker.getTickerStream())

--- a/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
+++ b/start/common/src/test/java/org/ethereum/beacon/LocalNetTest.java
@@ -142,17 +142,5 @@ public class LocalNetTest {
       System.out.println("===============================");
       schedulers.addTime(Duration.ofSeconds(10));
     }
-
-//    Thread.sleep(100000000);
-  }
-
-  static String slotInfo(SpecHelpers specHelpers, Time genesisTime, SlotNumber slot) {
-    ChainSpec spec = specHelpers.getChainSpec();
-    Time slotTime = genesisTime.plus(spec.getSlotDuration().times(slot.minus(spec.getGenesisSlot())));
-
-    double time = System.currentTimeMillis() - slotTime.getValue() * 1000;
-    time /= 1000;
-    return "Slot #" + slot.minus(spec.getGenesisSlot()) +
-        String.format(" %.1f sec from its time", time);
   }
 }

--- a/util/src/main/java/org/ethereum/beacon/schedulers/AbstractSchedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/AbstractSchedulers.java
@@ -1,0 +1,114 @@
+package org.ethereum.beacon.schedulers;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * The collection of standard Schedulers, Scheduler factory and system time supplier
+ *
+ * For debugging and testing the default <code>Schedulers</code> instance can be replaced
+ * with appropriate one
+ */
+public abstract class AbstractSchedulers implements Schedulers {
+  private static final int BLOCKING_THREAD_COUNT = 128;
+
+  private Scheduler cpuHeavyScheduler;
+  private Scheduler blockingScheduler;
+  private Scheduler eventsScheduler;
+  private reactor.core.scheduler.Scheduler eventsReactorScheduler;
+  private ScheduledExecutorService eventsExecutor;
+
+  @Override
+  public long getCurrentTime() {
+    return System.currentTimeMillis();
+  }
+
+  protected abstract ScheduledExecutorService createExecutor(String namePattern, int threads);
+
+  protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
+    return new ExecutorScheduler(executorService);
+  }
+
+  @Override
+  public Scheduler cpuHeavy() {
+    if (cpuHeavyScheduler == null) {
+      synchronized (this) {
+        if (cpuHeavyScheduler == null) {
+          cpuHeavyScheduler = createCpuHeavy();
+        }
+      }
+    }
+    return cpuHeavyScheduler;
+  }
+
+  protected Scheduler createCpuHeavy() {
+    return createExecutorScheduler(createCpuHeavyExecutor());
+  }
+
+  protected ScheduledExecutorService createCpuHeavyExecutor() {
+    return createExecutor("Schedulers-cpuHeavy-%d", Runtime.getRuntime().availableProcessors());
+  }
+
+  @Override
+  public Scheduler blocking() {
+    if (blockingScheduler == null) {
+      synchronized (this) {
+        if (blockingScheduler == null) {
+          blockingScheduler = createBlocking();
+        }
+      }
+    }
+    return blockingScheduler;
+  }
+
+  protected Scheduler createBlocking() {
+    return createExecutorScheduler(createBlockingExecutor());
+  }
+
+  protected ScheduledExecutorService createBlockingExecutor() {
+    return createExecutor("Schedulers-blocking-%d", BLOCKING_THREAD_COUNT);
+  }
+
+  @Override
+  public Scheduler events() {
+    if (eventsScheduler == null) {
+      synchronized (this) {
+        if (eventsScheduler == null) {
+          eventsScheduler = createEvents();
+        }
+      }
+    }
+    return eventsScheduler;
+  }
+
+  protected Scheduler createEvents() {
+    return createExecutorScheduler(getEventsExecutor());
+  }
+
+  protected ScheduledExecutorService getEventsExecutor() {
+    if (eventsExecutor == null) {
+      eventsExecutor = createExecutor("Schedulers-events", 1);
+    }
+    return eventsExecutor;
+  }
+
+  @Override
+  public reactor.core.scheduler.Scheduler reactorEvents() {
+    if (eventsReactorScheduler == null) {
+      synchronized (this) {
+        if (eventsReactorScheduler == null) {
+          eventsReactorScheduler = createReactorEvents();
+        }
+      }
+    }
+    return eventsReactorScheduler;
+  }
+
+  protected reactor.core.scheduler.Scheduler createReactorEvents() {
+    return reactor.core.scheduler.Schedulers.fromExecutor(getEventsExecutor());
+  }
+
+  @Override
+  public Scheduler newParallelDaemon(String threadNamePattern, int threadPoolCount) {
+    return createExecutorScheduler(createExecutor(threadNamePattern, threadPoolCount));
+  }
+}

--- a/util/src/main/java/org/ethereum/beacon/schedulers/ControlledExecutorService.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/ControlledExecutorService.java
@@ -2,11 +2,27 @@ package org.ethereum.beacon.schedulers;
 
 import java.util.concurrent.ScheduledExecutorService;
 
-
+/**
+ * The <code>ScheduledExecutorService</code> which functions based on the
+ * current system time supplied with {@link #setCurrentTime(long)} instead of
+ * <code>System.currentTimeMillis()</code>
+ *
+ * Initial current time is 0
+ */
 public interface ControlledExecutorService extends ScheduledExecutorService {
 
+  /**
+   * Sets internal clock time and executes any tasks scheduled in period from
+   * the previous time till new <code>currentTime</code> inclusive.
+   * Periodic tasks are executed several times if scheduled so.
+   * @param currentTime should be >= the last set time
+   */
   void setCurrentTime(long currentTime);
 
+  /**
+   * Return the nearest time a task is scheduled for inside this executor
+   * @return the nearest task time or {@link Long#MAX_VALUE} if no tasks scheduled at the moment
+   */
   long getNextScheduleTime();
 
 }

--- a/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulers.java
@@ -1,66 +1,38 @@
 package org.ethereum.beacon.schedulers;
 
 import java.time.Duration;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 
-public class ControlledSchedulers extends Schedulers {
+/**
+ * Special Schedulers implementation which is mostly suitable for testing and emulation.
+ * The system time is controlled manually and all the schedulers execute tasks according
+ * to this time.
+ * Initial system time is equal to 0
+ */
+public interface ControlledSchedulers extends Schedulers {
 
-  private final List<ControlledExecutorService> controlledExecutors = new CopyOnWriteArrayList<>();
-  private long currentTime = 0;
+  /**
+   * Sets the next system timestamp.
+   * After the call the {@link #getCurrentTime()} method will return <code>newTime</code>
+   * however during this call if a task for some Scheduler is scheduled for time T (T <= <code>newTime</code>)
+   * the {@link #getCurrentTime()} should return T until the task completes execution.
+   * All the tasks scheduled for the period from the previous till the new time are executed
+   * sequentially in time increasing order.
+   * Periodic tasks would execute several times if scheduled accordingly
+   */
+  void setCurrentTime(long newTime);
 
-  @Override
-  public long getCurrentTime() {
-    return currentTime;
-  }
-
-  public void setCurrentTime(long newTime) {
-    assert newTime >= currentTime;
-    while (true) {
-      Optional<ControlledExecutorService> nextSchedulerToRunOpt =
-          controlledExecutors.stream()
-              .min(Comparator.comparingLong(ex -> ex.getNextScheduleTime()));
-      if (!nextSchedulerToRunOpt.isPresent()) {
-        break;
-      }
-      ControlledExecutorService nextSchedulerToRun = nextSchedulerToRunOpt.get();
-      long time = nextSchedulerToRun.getNextScheduleTime();
-      if (time > newTime) {
-        break;
-      }
-      currentTime = time;
-      nextSchedulerToRun.setCurrentTime(currentTime);
-    }
-    currentTime = newTime;
-    controlledExecutors.forEach(e -> e.setCurrentTime(newTime));
-  }
-
-  public void addTime(Duration duration) {
+  /**
+   * Just a handy helper method for {@link #setCurrentTime(long)}
+   */
+  default void addTime(Duration duration) {
     addTime(duration.toMillis());
   }
 
-  public void addTime(long millis) {
+  /**
+   * Just a handy helper method for {@link #setCurrentTime(long)}
+   */
+  default void addTime(long millis) {
     setCurrentTime(getCurrentTime() + millis);
   }
 
-  @Override
-  protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
-    return new ErrorHandlingScheduler(new ExecutorScheduler(executorService), e -> e.printStackTrace());
-  }
-
-  @Override
-  protected ScheduledExecutorService createExecutor(String namePattern, int threads) {
-    ControlledExecutorService service = new ControlledExecutorServiceImpl(createDelegateExecutor());
-    controlledExecutors.add(service);
-    service.setCurrentTime(currentTime);
-    return service;
-  }
-
-  protected Executor createDelegateExecutor() {
-    return Runnable::run;
-  }
 }

--- a/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulers.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class ControlledSchedulers extends Schedulers {
@@ -53,9 +54,13 @@ public class ControlledSchedulers extends Schedulers {
 
   @Override
   protected ScheduledExecutorService createExecutor(String namePattern, int threads) {
-    ControlledExecutorService service = new ControlledExecutorServiceImpl();
+    ControlledExecutorService service = new ControlledExecutorServiceImpl(createDelegateExecutor());
     controlledExecutors.add(service);
     service.setCurrentTime(currentTime);
     return service;
+  }
+
+  protected Executor createDelegateExecutor() {
+    return Runnable::run;
   }
 }

--- a/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulersImpl.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulersImpl.java
@@ -1,0 +1,58 @@
+package org.ethereum.beacon.schedulers;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class ControlledSchedulersImpl extends AbstractSchedulers implements ControlledSchedulers {
+
+  private final List<ControlledExecutorService> controlledExecutors = new CopyOnWriteArrayList<>();
+  private long currentTime = 0;
+
+  @Override
+  public long getCurrentTime() {
+    return currentTime;
+  }
+
+  @Override
+  public void setCurrentTime(long newTime) {
+    assert newTime >= currentTime;
+    while (true) {
+      Optional<ControlledExecutorService> nextSchedulerToRunOpt =
+          controlledExecutors.stream()
+              .min(Comparator.comparingLong(ex -> ex.getNextScheduleTime()));
+      if (!nextSchedulerToRunOpt.isPresent()) {
+        break;
+      }
+      ControlledExecutorService nextSchedulerToRun = nextSchedulerToRunOpt.get();
+      long time = nextSchedulerToRun.getNextScheduleTime();
+      if (time > newTime) {
+        break;
+      }
+      currentTime = time;
+      nextSchedulerToRun.setCurrentTime(currentTime);
+    }
+    currentTime = newTime;
+    controlledExecutors.forEach(e -> e.setCurrentTime(newTime));
+  }
+
+  @Override
+  protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
+    return new ErrorHandlingScheduler(new ExecutorScheduler(executorService), e -> e.printStackTrace());
+  }
+
+  @Override
+  protected ScheduledExecutorService createExecutor(String namePattern, int threads) {
+    ControlledExecutorService service = new ControlledExecutorServiceImpl(createDelegateExecutor());
+    controlledExecutors.add(service);
+    service.setCurrentTime(currentTime);
+    return service;
+  }
+
+  protected Executor createDelegateExecutor() {
+    return Runnable::run;
+  }
+}

--- a/util/src/main/java/org/ethereum/beacon/schedulers/DefaultSchedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/DefaultSchedulers.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
-public class DefaultSchedulers extends Schedulers {
+public class DefaultSchedulers extends AbstractSchedulers {
 
   private Consumer<Throwable> errorHandler =
       t -> {

--- a/util/src/main/java/org/ethereum/beacon/schedulers/Schedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/Schedulers.java
@@ -11,23 +11,6 @@ import java.util.concurrent.ScheduledExecutorService;
 public abstract class Schedulers {
   private static final int BLOCKING_THREAD_COUNT = 128;
 
-  private static Schedulers current;
-
-  public static Schedulers get() {
-    if (current == null) {
-      resetToDefault();
-    }
-    return current;
-  }
-
-  public static void set(Schedulers newStaticSchedulers) {
-    current = newStaticSchedulers;
-  }
-
-  public static void resetToDefault() {
-    current = new DefaultSchedulers();
-  }
-
   private Scheduler cpuHeavyScheduler;
   private Scheduler blockingScheduler;
   private Scheduler eventsScheduler;

--- a/util/src/main/java/org/ethereum/beacon/schedulers/Schedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/Schedulers.java
@@ -1,112 +1,93 @@
 package org.ethereum.beacon.schedulers;
 
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 /**
  * The collection of standard Schedulers, Scheduler factory and system time supplier
- *
- * For debugging and testing the default <code>Schedulers</code> instance can be replaced
- * with appropriate one
+ * Any scheduler withing a system should be obtained or created via this interface
  */
-public abstract class Schedulers {
-  private static final int BLOCKING_THREAD_COUNT = 128;
+public interface Schedulers {
 
-  private Scheduler cpuHeavyScheduler;
-  private Scheduler blockingScheduler;
-  private Scheduler eventsScheduler;
-  private reactor.core.scheduler.Scheduler eventsReactorScheduler;
-  private ScheduledExecutorService eventsExecutor;
-
-  public long getCurrentTime() {
-    return System.currentTimeMillis();
+  /**
+   * Creates default Schedulers implementation for production functioning
+   */
+  static Schedulers createDefault() {
+    return new DefaultSchedulers();
   }
 
-  protected abstract ScheduledExecutorService createExecutor(String namePattern, int threads);
-
-  protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
-    return new ExecutorScheduler(executorService);
-  }
-
-  public Scheduler cpuHeavy() {
-    if (cpuHeavyScheduler == null) {
-      synchronized (this) {
-        if (cpuHeavyScheduler == null) {
-          cpuHeavyScheduler = createCpuHeavy();
-        }
+  /**
+   * Creates the ControlledSchedulers implementation (normally for testing or emulation)
+   * with the specified delegate Executor factory.
+   * @param delegateExecutor all the tasks are finally executed on executors created by this
+   * factory. Normally a single executor should be sufficient and could be supplied as
+   * <code>() -> mySingleExecutor</code>
+   */
+  static ControlledSchedulers createControlled(Supplier<Executor> delegateExecutor) {
+    return new ControlledSchedulersImpl() {
+      @Override
+      protected Executor createDelegateExecutor() {
+        return delegateExecutor.get();
       }
-    }
-    return cpuHeavyScheduler;
+    };
   }
 
-  protected Scheduler createCpuHeavy() {
-    return createExecutorScheduler(createCpuHeavyExecutor());
+  /**
+   * Creates the ControlledSchedulers implementation (normally for testing or emulation)
+   * which executes all the tasks immediately on the same thread or if a task scheduled for
+   * later execution then this task would be executed within appropriate
+   * {@link ControlledSchedulers#setCurrentTime(long)} call
+   */
+  static ControlledSchedulers createControlled() {
+    return createControlled(() -> Runnable::run);
   }
 
-  protected ScheduledExecutorService createCpuHeavyExecutor() {
-    return createExecutor("Schedulers-cpuHeavy-%d", Runtime.getRuntime().availableProcessors());
+  /**
+   * Returns the current system time
+   * This method should be used by all components to obtain the current system time
+   * <code>System.currentTimeMillis()</code> (or other standard Java means) is prohibited.
+   */
+  long getCurrentTime();
+
+  /**
+   * Scheduler to execute CPU heavy tasks
+   * This is normally based on a thread pool with the number of threads
+   * equal to number of CPU cores
+   */
+  Scheduler cpuHeavy();
+
+  /**
+   * The scheduler to execute disk read/write tasks (like DB access, file read/write etc)
+   * and other tasks with potentially short blocking time.
+   * Tasks with potentially longer blocking time (like waiting for network response) is
+   * highly recommended to execute in a non-blocking (reactive) manner or at least on
+   * a dedicated Scheduler
+   *
+   * This Scheduler is normally based on a dynamic pool with sufficient number of threads
+   */
+  Scheduler blocking();
+
+  /**
+   * Dedicated Scheduler for internal system asynchronous events
+   */
+  Scheduler events();
+
+  /**
+   * Reactor Scheduler decorator for {@link #events()} Scheduler. Those two shares the
+   * same thread/pool
+   */
+  reactor.core.scheduler.Scheduler reactorEvents();
+
+  /**
+   * Creates new single thread Scheduler with the specified thread name
+   */
+  default Scheduler newSingleThreadDaemon(String threadName) {
+    return newParallelDaemon(threadName, 1);
   }
 
-  public Scheduler blocking() {
-    if (blockingScheduler == null) {
-      synchronized (this) {
-        if (blockingScheduler == null) {
-          blockingScheduler = createBlocking();
-        }
-      }
-    }
-    return blockingScheduler;
-  }
-
-  protected Scheduler createBlocking() {
-    return createExecutorScheduler(createBlockingExecutor());
-  }
-
-  protected ScheduledExecutorService createBlockingExecutor() {
-    return createExecutor("Schedulers-blocking-%d", BLOCKING_THREAD_COUNT);
-  }
-
-  public Scheduler events() {
-    if (eventsScheduler == null) {
-      synchronized (this) {
-        if (eventsScheduler == null) {
-          eventsScheduler = createEvents();
-        }
-      }
-    }
-    return eventsScheduler;
-  }
-
-  protected Scheduler createEvents() {
-    return createExecutorScheduler(getEventsExecutor());
-  }
-
-  protected ScheduledExecutorService getEventsExecutor() {
-    if (eventsExecutor == null) {
-      eventsExecutor = createExecutor("Schedulers-events", 1);
-    }
-    return eventsExecutor;
-  }
-
-  public reactor.core.scheduler.Scheduler reactorEvents() {
-    if (eventsReactorScheduler == null) {
-      synchronized (this) {
-        if (eventsReactorScheduler == null) {
-          eventsReactorScheduler = createReactorEvents();
-        }
-      }
-    }
-    return eventsReactorScheduler;
-  }
-
-  protected reactor.core.scheduler.Scheduler createReactorEvents() {
-    return reactor.core.scheduler.Schedulers.fromExecutor(getEventsExecutor());
-  }
-
-  public Scheduler newSingleThreadDaemon(String threadName) {
-    return createExecutorScheduler(createExecutor(threadName, 1));
-  }
-
-  public Scheduler newParallelDaemon(String threadNamePattern, int threadPoolCount) {
-    return createExecutorScheduler(createExecutor(threadNamePattern, threadPoolCount));
-  }
+  /**
+   * Creates new multi-thread Scheduler with the specified thread namePattern and
+   * number of pool threads
+   */
+  Scheduler newParallelDaemon(String threadNamePattern, int threadPoolCount);
 }

--- a/validator/src/test/java/org/ethereum/beacon/validator/BeaconChainValidatorTest.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/BeaconChainValidatorTest.java
@@ -6,8 +6,11 @@ import java.util.Random;
 import org.ethereum.beacon.chain.observer.ObservableBeaconState;
 import org.ethereum.beacon.chain.util.ObservableBeaconStateTestUtil;
 import org.ethereum.beacon.consensus.SpecHelpers;
+import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.ValidatorIndex;
+import org.ethereum.beacon.schedulers.DefaultSchedulers;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.validator.util.ValidatorServiceTestUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -18,7 +21,9 @@ public class BeaconChainValidatorTest {
   @Test
   public void recentStateIsKept() {
     Random random = new Random();
-    SpecHelpers specHelpers = Mockito.spy(SpecHelpers.createDefault());
+    Schedulers schedulers = new DefaultSchedulers();
+    SpecHelpers specHelpers =
+        Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
     BeaconChainValidator validator =
         ValidatorServiceTestUtil.mockBeaconChainValidator(random, specHelpers);
@@ -44,7 +49,9 @@ public class BeaconChainValidatorTest {
   @Test
   public void outboundRecentStateIsIgnored() {
     Random random = new Random();
-    SpecHelpers specHelpers = Mockito.spy(SpecHelpers.createDefault());
+    Schedulers schedulers = new DefaultSchedulers();
+    SpecHelpers specHelpers =
+        Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
     BeaconChainValidator validator =
         ValidatorServiceTestUtil.mockBeaconChainValidator(random, specHelpers);
@@ -75,7 +82,9 @@ public class BeaconChainValidatorTest {
   @Test
   public void initService() {
     Random random = new Random();
-    SpecHelpers specHelpers = Mockito.spy(SpecHelpers.createDefault());
+    Schedulers schedulers = new DefaultSchedulers();
+    SpecHelpers specHelpers =
+        Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
     BeaconChainValidator validator =
         ValidatorServiceTestUtil.mockBeaconChainValidator(random, specHelpers);
@@ -114,7 +123,9 @@ public class BeaconChainValidatorTest {
   @Test
   public void runValidatorTasks() {
     Random random = new Random();
-    SpecHelpers specHelpers = Mockito.spy(SpecHelpers.createDefault());
+    Schedulers schedulers = new DefaultSchedulers();
+    SpecHelpers specHelpers =
+        Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
     BeaconChainValidator validator =
         ValidatorServiceTestUtil.mockBeaconChainValidator(random, specHelpers);

--- a/validator/src/test/java/org/ethereum/beacon/validator/BeaconChainValidatorTest.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/BeaconChainValidatorTest.java
@@ -21,7 +21,7 @@ public class BeaconChainValidatorTest {
   @Test
   public void recentStateIsKept() {
     Random random = new Random();
-    Schedulers schedulers = new DefaultSchedulers();
+    Schedulers schedulers = Schedulers.createDefault();
     SpecHelpers specHelpers =
         Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
@@ -49,7 +49,7 @@ public class BeaconChainValidatorTest {
   @Test
   public void outboundRecentStateIsIgnored() {
     Random random = new Random();
-    Schedulers schedulers = new DefaultSchedulers();
+    Schedulers schedulers = Schedulers.createDefault();
     SpecHelpers specHelpers =
         Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
@@ -82,7 +82,7 @@ public class BeaconChainValidatorTest {
   @Test
   public void initService() {
     Random random = new Random();
-    Schedulers schedulers = new DefaultSchedulers();
+    Schedulers schedulers = Schedulers.createDefault();
     SpecHelpers specHelpers =
         Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 
@@ -123,7 +123,7 @@ public class BeaconChainValidatorTest {
   @Test
   public void runValidatorTasks() {
     Random random = new Random();
-    Schedulers schedulers = new DefaultSchedulers();
+    Schedulers schedulers = Schedulers.createDefault();
     SpecHelpers specHelpers =
         Mockito.spy(SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, schedulers::getCurrentTime));
 

--- a/validator/src/test/java/org/ethereum/beacon/validator/attester/BeaconChainAttesterTest.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/attester/BeaconChainAttesterTest.java
@@ -13,6 +13,7 @@ import org.ethereum.beacon.core.BeaconState;
 import org.ethereum.beacon.core.operations.Attestation;
 import org.ethereum.beacon.core.operations.attestation.AttestationData;
 import org.ethereum.beacon.core.operations.attestation.AttestationDataAndCustodyBit;
+import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.spec.SignatureDomains;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.core.types.ShardNumber;
@@ -30,7 +31,7 @@ public class BeaconChainAttesterTest {
   public void attestASlot() {
     Random random = new Random();
 
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
 
     MessageSigner<BLSSignature> signer = MessageSignerTestUtil.createBLSSigner();
     BeaconChainAttesterImpl attester = BeaconChainAttesterTestUtil.mockAttester(specHelpers);

--- a/validator/src/test/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerTest.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerTest.java
@@ -25,6 +25,7 @@ import org.ethereum.beacon.core.operations.Exit;
 import org.ethereum.beacon.core.operations.ProposerSlashing;
 import org.ethereum.beacon.core.operations.slashing.AttesterSlashing;
 import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.spec.SignatureDomains;
 import org.ethereum.beacon.core.state.Eth1Data;
 import org.ethereum.beacon.core.types.BLSSignature;
@@ -52,7 +53,7 @@ public class BeaconChainProposerTest {
   public void proposeABlock() {
     Random random = new Random();
 
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     DepositContract depositContract =
         DepositContractTestUtil.mockDepositContract(random, Collections.emptyList());
     BlockTransition<BeaconStateEx> perBlockTransition =
@@ -80,7 +81,7 @@ public class BeaconChainProposerTest {
   public void proposeABlockWithOperations() {
     Random random = new Random();
 
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     DepositContract depositContract =
         DepositContractTestUtil.mockDepositContract(random, Collections.emptyList());
     BlockTransition<BeaconStateEx> perBlockTransition =
@@ -141,7 +142,7 @@ public class BeaconChainProposerTest {
   public void proposeABlockWithDeposits() {
     Random random = new Random();
 
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
 
     List<Deposit> deposits =
         DepositTestUtil.createRandomList(
@@ -193,7 +194,7 @@ public class BeaconChainProposerTest {
   public void proposeABlockWithEpochTransition() {
     Random random = new Random();
 
-    SpecHelpers specHelpers = SpecHelpers.createDefault();
+    SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     DepositContract depositContract =
         DepositContractTestUtil.mockDepositContract(random, Collections.emptyList());
     BlockTransition<BeaconStateEx> perBlockTransition =

--- a/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
@@ -43,6 +43,6 @@ public abstract class ValidatorServiceTestUtil {
 
     return Mockito.spy(
         new BeaconChainValidator(pubkey, proposer, attester, specHelpers,
-            signer, Mono.empty(), new DefaultSchedulers()));
+            signer, Mono.empty(), Schedulers.createDefault()));
   }
 }

--- a/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
@@ -11,6 +11,7 @@ import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.pow.DepositContract;
 import org.ethereum.beacon.pow.util.DepositContractTestUtil;
+import org.ethereum.beacon.schedulers.DefaultSchedulers;
 import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.validator.BeaconChainAttester;
 import org.ethereum.beacon.validator.BeaconChainProposer;
@@ -42,6 +43,6 @@ public abstract class ValidatorServiceTestUtil {
 
     return Mockito.spy(
         new BeaconChainValidator(pubkey, proposer, attester, specHelpers,
-            signer, Mono.empty(), Schedulers.get()));
+            signer, Mono.empty(), new DefaultSchedulers()));
   }
 }

--- a/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
@@ -11,6 +11,7 @@ import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.pow.DepositContract;
 import org.ethereum.beacon.pow.util.DepositContractTestUtil;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.validator.BeaconChainAttester;
 import org.ethereum.beacon.validator.BeaconChainProposer;
 import org.ethereum.beacon.validator.BeaconChainValidator;
@@ -40,6 +41,7 @@ public abstract class ValidatorServiceTestUtil {
     MessageSigner<BLSSignature> signer = MessageSignerTestUtil.createBLSSigner();
 
     return Mockito.spy(
-        new BeaconChainValidator(pubkey, proposer, attester, specHelpers, signer, Mono.empty()));
+        new BeaconChainValidator(pubkey, proposer, attester, specHelpers,
+            signer, Mono.empty(), Schedulers.get()));
   }
 }


### PR DESCRIPTION
Pass `Schedulers` to all classes as parameter. 
This will help to separate validator instances running in a single jvm emulator. This will also allow to manage separate logging contexts for different validators 