### PR TITLE
Proposer needs to compose a block on top of a state before EpochTransition applied

### DIFF
--- a/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableBeaconState.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableBeaconState.java
@@ -10,12 +10,23 @@ import org.ethereum.beacon.core.BeaconState;
 public class ObservableBeaconState {
   private final BeaconBlock head;
   private final BeaconState latestSlotState;
+  private final BeaconState latestSlotStateWithoutEpoch;
   private final PendingOperations pendingOperations;
+
+  public ObservableBeaconState(BeaconBlock head, BeaconState latestSlotState,
+      BeaconState latestSlotStateWithoutEpoch,
+      PendingOperations pendingOperations) {
+    this.head = head;
+    this.latestSlotState = latestSlotState;
+    this.latestSlotStateWithoutEpoch = latestSlotStateWithoutEpoch;
+    this.pendingOperations = pendingOperations;
+  }
 
   public ObservableBeaconState(
       BeaconBlock head, BeaconState latestSlotState, PendingOperations pendingOperations) {
     this.head = head;
     this.latestSlotState = latestSlotState;
+    this.latestSlotStateWithoutEpoch = latestSlotState;
     this.pendingOperations = pendingOperations;
   }
 
@@ -25,6 +36,10 @@ public class ObservableBeaconState {
 
   public BeaconState getLatestSlotState() {
     return latestSlotState;
+  }
+
+  public BeaconState getLatestSlotStateWithoutEpoch() {
+    return latestSlotStateWithoutEpoch;
   }
 
   public PendingOperations getPendingOperations() {

--- a/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorImpl.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorImpl.java
@@ -251,30 +251,45 @@ public class ObservableStateProcessorImpl implements ObservableStateProcessor {
     PendingOperations pendingOperations = new PendingOperationsState(drainAttestationCache());
     pendingOperationsSink.onNext(pendingOperations);
     updateHead(pendingOperations);
-    this.latestState =
-        applySlotTransitions(latestState, specHelpers.hash_tree_root(head.getBlock()), newSlot);
-    ObservableBeaconState newObservableState =
-        new ObservableBeaconState(head.getBlock(), latestState, pendingOperations);
+
+    BeaconState originalState = latestState;
+    BeaconState beaconStateWithoutEpoch = applySlotTransitionsWithoutEpoch(originalState,
+        specHelpers.hash_tree_root(head.getBlock()), newSlot);
+    BeaconState newBeaconState = applyEpochTransitionIfNeeded(beaconStateWithoutEpoch);
+    latestState = newBeaconState;
+    ObservableBeaconState newObservableState = new ObservableBeaconState(
+            head.getBlock(), newBeaconState, beaconStateWithoutEpoch, pendingOperations);
     if (!newObservableState.equals(observableState)) {
       this.observableState = newObservableState;
       observableStateSink.onNext(newObservableState);
     }
   }
 
+  private BeaconState applyEpochTransitionIfNeeded(BeaconState source) {
+    if (specHelpers.is_epoch_end(source.getSlot())) {
+      BeaconStateEx stateEx =
+          new BeaconStateEx(source, specHelpers.get_block_root(source, source.getSlot().decrement()));
+      return perEpochTransition.apply(stateEx).getCanonicalState();
+    } else {
+      return source;
+    }
+  }
+
   /**
-   * Applies next slot transition and if it's required - epoch transition
+   * Applies next slot transitions until the <code>targetSlot</code> but
+   * doesn't apply EpochTransition for the <code>targetSlot</code>
    *
    * @param source Source state
    * @param latestChainBlock Latest chain block
    * @return new state, result of applied transition to the latest input state
    */
-  private BeaconState applySlotTransitions(
+  private BeaconState applySlotTransitionsWithoutEpoch(
       BeaconState source, Hash32 latestChainBlock, SlotNumber targetSlot) {
 
     BeaconStateEx stateEx = new BeaconStateEx(source, latestChainBlock);
     for (SlotNumber slot : source.getSlot().increment().iterateTo(targetSlot.increment())) {
       stateEx = perSlotTransition.apply(stateEx);
-      if (specHelpers.is_epoch_end(slot)) {
+      if (specHelpers.is_epoch_end(slot) && !slot.equals(targetSlot)) {
         stateEx = perEpochTransition.apply(stateEx);
       }
     }

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/AttestationVerifier.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/AttestationVerifier.java
@@ -62,10 +62,10 @@ public class AttestationVerifier implements OperationVerifier<Attestation> {
 
     // Verify that attestation.data.justified_epoch is equal to
     // state.justified_epoch
-    // if attestation.data.slot >= get_epoch_start_slot(get_current_epoch(state))
-    // else state.previous_justified_epoch
+    // if slot_to_epoch(attestation.data.slot + 1) >= get_current_epoch(state)
+    // else state.previous_justified_epoch.
     if (!data.getJustifiedEpoch().equals(
-        data.getSlot().greaterEqual(specHelpers.get_epoch_start_slot(specHelpers.get_current_epoch(state))) ?
+        specHelpers.slot_to_epoch(data.getSlot().increment()).greaterEqual(specHelpers.get_current_epoch(state)) ?
         state.getJustifiedEpoch() : state.getPreviousJustifiedEpoch())) {
       return failedResult(
           "Attestation.data.justified_epoch is invalid");

--- a/validator/src/main/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerImpl.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerImpl.java
@@ -72,7 +72,7 @@ public class BeaconChainProposerImpl implements BeaconChainProposer {
   @Override
   public BeaconBlock propose(
       ObservableBeaconState observableState, MessageSigner<BLSSignature> signer) {
-    BeaconState state = observableState.getLatestSlotState();
+    BeaconState state = observableState.getLatestSlotStateWithoutEpoch();
 
     Hash32 parentRoot = specHelpers.get_block_root(state, state.getSlot().decrement());
     BLSSignature randaoReveal = getRandaoReveal(state, signer);


### PR DESCRIPTION
Currently we have an issue with a new block composition and `ObservableState`: the latter broadcasts new pending states by applying `Slot` and `Epoch` transitions on top of last known head state. But the block needs to be composed on top of a state *after* `Slot` transition but *before* `Epoch` transition (worth to mention that `Block.state_root` should refer to the state *after* `Epoch` transition)

The proposed solution is to add 'intermediate' state (before applying Epoch transition) to the `ObservableBeaconState` so the proposer can take this state for block composition