### PR TITLE
ObservableStateProcessor: missing attestations detected

### DIFF
--- a/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorImpl.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorImpl.java
@@ -3,14 +3,11 @@ package org.ethereum.beacon.chain.observer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Collectors;
 import org.ethereum.beacon.chain.BeaconChainHead;
 import org.ethereum.beacon.chain.LMDGhostHeadFunction;
 import org.ethereum.beacon.chain.storage.BeaconChainStorage;
@@ -30,12 +27,12 @@ import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.ValidatorIndex;
 import org.ethereum.beacon.schedulers.Scheduler;
 import org.ethereum.beacon.schedulers.Schedulers;
+import org.javatuples.Pair;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.ReplayProcessor;
 import tech.pegasys.artemis.ethereum.core.Hash32;
 import tech.pegasys.artemis.util.collections.ReadList;
-import tech.pegasys.artemis.util.uint.UInt64;
 
 public class ObservableStateProcessorImpl implements ObservableStateProcessor {
   private final BeaconTupleStorage tupleStorage;
@@ -58,8 +55,7 @@ public class ObservableStateProcessorImpl implements ObservableStateProcessor {
   private Scheduler continuousJobExecutor;
 
   private final List<Attestation> attestationBuffer = new ArrayList<>();
-  private final Map<BLSPubkey, Attestation> attestationCache = new HashMap<>();
-  private final Map<UInt64, Set<BLSPubkey>> validatorSlotCache = new HashMap<>();
+  private final Map<Pair<BLSPubkey, SlotNumber>, Attestation> attestationCache = new HashMap<>();
   private final Schedulers schedulers;
 
   private final ReplayProcessor<BeaconChainHead> headSink = ReplayProcessor.cacheLast();
@@ -157,30 +153,7 @@ public class ObservableStateProcessorImpl implements ObservableStateProcessor {
   }
 
   private synchronized void addValidatorAttestation(BLSPubkey pubKey, Attestation attestation) {
-    if (attestationCache.containsKey(pubKey)) {
-      Attestation oldAttestation = attestationCache.get(pubKey);
-      if (attestation.getData().getSlot().greater(oldAttestation.getData().getSlot())) {
-        attestationCache.put(pubKey, attestation);
-        validatorSlotCache.get(oldAttestation.getData().getSlot()).remove(pubKey);
-        addToSlotCache(attestation.getData().getSlot(), pubKey);
-      } else {
-        // XXX: If several such attestations exist, use the one the validator v observed first
-        // so no need to swap it
-      }
-    } else {
-      attestationCache.put(pubKey, attestation);
-      addToSlotCache(attestation.getData().getSlot(), pubKey);
-    }
-  }
-
-  private void addToSlotCache(UInt64 slot, BLSPubkey pubKey) {
-    if (validatorSlotCache.containsKey(slot)) {
-      validatorSlotCache.get(slot).add(pubKey);
-    } else {
-      Set<BLSPubkey> pubKeysSet = new HashSet<>();
-      pubKeysSet.add(pubKey);
-      validatorSlotCache.put(slot, pubKeysSet);
-    }
+    attestationCache.put(Pair.with(pubKey, attestation.getData().getSlot()), attestation);
   }
 
   private synchronized void onNewAttestation(Attestation attestation) {
@@ -225,30 +198,25 @@ public class ObservableStateProcessorImpl implements ObservableStateProcessor {
   }
 
   private synchronized void removeValidatorAttestation(BLSPubkey pubkey, SlotNumber slot) {
-    attestationCache.remove(pubkey);
-    if (validatorSlotCache.containsKey(slot)) {
-      validatorSlotCache.get(slot).remove(pubkey);
-    }
+    attestationCache.remove(Pair.with(pubkey, slot));
   }
 
   /** Purges all entries for slot and before */
-  private synchronized void purgeAttestations(UInt64 slot) {
-    Iterator<Entry<UInt64, Set<BLSPubkey>>> entryIterator = validatorSlotCache.entrySet().iterator();
-    while (entryIterator.hasNext()) {
-      Entry<UInt64, Set<BLSPubkey>> entry = entryIterator.next();
-      if (entry.getKey().compareTo(slot) <= 0) {
-        entry.getValue().forEach(attestationCache::remove);
-        entryIterator.remove();
-      }
-    }
+  private synchronized void purgeAttestations(SlotNumber slot) {
+    attestationCache.entrySet()
+        .removeIf(entry -> entry.getValue().getData().getSlot().lessEqual(slot));
   }
 
-  private synchronized Map<BLSPubkey, Attestation> drainAttestationCache() {
-    return new HashMap<>(attestationCache);
+  private synchronized Map<BLSPubkey, List<Attestation>> copyAttestationCache() {
+    return attestationCache.entrySet().stream()
+        .collect(
+            Collectors.groupingBy(
+                e -> e.getKey().getValue0(),
+                Collectors.mapping(Entry::getValue, Collectors.toList())));
   }
 
   private void updateCurrentObservableState(SlotNumber newSlot) {
-    PendingOperations pendingOperations = new PendingOperationsState(drainAttestationCache());
+    PendingOperations pendingOperations = new PendingOperationsState(copyAttestationCache());
     pendingOperationsSink.onNext(pendingOperations);
     updateHead(pendingOperations);
 
@@ -303,7 +271,7 @@ public class ObservableStateProcessorImpl implements ObservableStateProcessor {
   private void updateHead(PendingOperations pendingOperations) {
     BeaconBlock newHead =
         headFunction.getHead(
-            validatorRecord -> pendingOperations.findAttestation(validatorRecord.getPubKey()));
+            validatorRecord -> pendingOperations.getLatestAttestation(validatorRecord.getPubKey()));
     if (this.head != null && this.head.getBlock().equals(newHead)) {
       return; // == old
     }

--- a/chain/src/main/java/org/ethereum/beacon/chain/observer/PendingOperations.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/observer/PendingOperations.java
@@ -15,7 +15,7 @@ public interface PendingOperations {
 
   List<Attestation> getAttestations();
 
-  Optional<Attestation> findAttestation(BLSPubkey pubKey);
+  Optional<Attestation> getLatestAttestation(BLSPubkey pubKey);
 
   List<ProposerSlashing> peekProposerSlashings(int maxCount);
 

--- a/chain/src/main/java/org/ethereum/beacon/chain/observer/PendingOperationsState.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/observer/PendingOperationsState.java
@@ -2,7 +2,7 @@ package org.ethereum.beacon.chain.observer;
 
 import static java.util.stream.Collectors.groupingBy;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -22,20 +22,21 @@ import org.ethereum.beacon.crypto.BLS381;
 
 public class PendingOperationsState implements PendingOperations {
 
-  Map<BLSPubkey, Attestation> attestations;
+  Map<BLSPubkey, List<Attestation>> attestations;
 
-  public PendingOperationsState(Map<BLSPubkey, Attestation> attestations) {
+  public PendingOperationsState(Map<BLSPubkey, List<Attestation>> attestations) {
     this.attestations = attestations;
   }
 
   @Override
-  public Optional<Attestation> findAttestation(BLSPubkey pubKey) {
-    return Optional.ofNullable(attestations.get(pubKey));
+  public Optional<Attestation> getLatestAttestation(BLSPubkey pubKey) {
+    return Optional.ofNullable(attestations.get(pubKey))
+        .map(atts -> Collections.max(atts, Comparator.comparing(att -> att.getData().getSlot())));
   }
 
   @Override
   public List<Attestation> getAttestations() {
-    return new ArrayList<>(attestations.values());
+    return attestations.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
`ObservableStateProcessor` keeps only the recent attestation from an attester as a pending operation.
However there are situations when > 1 attestations from a single attester can be pending, e.g. when one attestation for the last epoch slot and then another for the first slot of the next epoch. 
While the LMD-GHOST should be fed by the latest attestation only the `ObservableState` should keep track of all attestations as they all can be included to the block.

Also simplify a bit the `ObservableStateProcessorImpl` by removing duplicating data structure 