### PR TITLE
Multi-validator service

### DIFF
--- a/chain/src/main/java/org/ethereum/beacon/chain/DefaultBeaconChain.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/DefaultBeaconChain.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.chain.storage.BeaconChainStorage;
 import org.ethereum.beacon.chain.storage.BeaconTuple;
 import org.ethereum.beacon.chain.storage.BeaconTupleStorage;
@@ -25,6 +27,8 @@ import reactor.core.publisher.ReplayProcessor;
 import tech.pegasys.artemis.ethereum.core.Hash32;
 
 public class DefaultBeaconChain implements MutableBeaconChain {
+
+  private static final Logger logger = LogManager.getLogger(DefaultBeaconChain.class);
 
   private final SpecHelpers specHelpers;
   private final BlockTransition<BeaconStateEx> initialTransition;
@@ -145,6 +149,15 @@ public class DefaultBeaconChain implements MutableBeaconChain {
 
     this.recentlyProcessed = newTuple;
     blockSink.onNext(newTuple);
+
+    logger.info(
+        "new block inserted: {}",
+        newTuple
+            .getBlock()
+            .toString(
+                specHelpers.getChainSpec(),
+                newTuple.getState().getGenesisTime(),
+                specHelpers::hash_tree_root));
 
     return true;
   }

--- a/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationService.java
+++ b/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationService.java
@@ -4,6 +4,7 @@ import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.core.types.Gwei;
 import org.ethereum.beacon.validator.ValidatorService;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
 import org.ethereum.beacon.validator.crypto.MessageSigner;
 import tech.pegasys.artemis.ethereum.core.Address;
 import tech.pegasys.artemis.ethereum.core.Hash32;
@@ -19,8 +20,7 @@ import java.util.Optional;
  */
 public interface ValidatorRegistrationService {
   void start(
-      MessageSigner<BLSSignature> signer,
-      BLSPubkey pubKey,
+      BLS381Credentials credentials,
       @Nullable Hash32 withdrawalCredentials,
       @Nullable Gwei amount,
       @Nullable Address eth1From,

--- a/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationServiceImpl.java
+++ b/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationServiceImpl.java
@@ -11,7 +11,6 @@ import org.ethereum.beacon.core.BeaconState;
 import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.operations.deposit.DepositInput;
 import org.ethereum.beacon.core.state.ValidatorRecord;
-import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.core.types.EpochNumber;
 import org.ethereum.beacon.core.types.Gwei;
@@ -24,7 +23,7 @@ import org.ethereum.beacon.validator.BeaconChainProposer;
 import org.ethereum.beacon.validator.BeaconChainValidator;
 import org.ethereum.beacon.validator.ValidatorService;
 import org.ethereum.beacon.validator.attester.BeaconChainAttesterImpl;
-import org.ethereum.beacon.validator.crypto.MessageSigner;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
 import org.ethereum.beacon.validator.proposer.BeaconChainProposerImpl;
 import org.reactivestreams.Publisher;
 import reactor.core.Disposable;
@@ -60,8 +59,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
   private ValidatorRecord validatorRecord = null;
 
   // Validator
-  private MessageSigner<BLSSignature> signer;
-  private BLSPubkey pubKey;
+  private BLS381Credentials blsCredentials;
   private Hash32 withdrawalCredentials = null;
   private Gwei amount = null;
   private Address eth1From = null;
@@ -89,14 +87,11 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
 
   @Override
   public void start(
-      MessageSigner<BLSSignature> signer,
-      BLSPubkey pubKey,
+      BLS381Credentials credentials,
       @Nullable Hash32 withdrawalCredentials,
       @Nullable Gwei amount,
       @Nullable Address eth1From,
       @Nullable BytesValue eth1PrivKey) {
-    this.signer = signer;
-    this.pubKey = pubKey;
     this.executor =
         Executors.newSingleThreadExecutor(
             runnable -> {
@@ -137,7 +132,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
     BeaconState latestState = getLatestState();
     Optional<ValidatorRecord> validatorRecordOptional =
         latestState.getValidatorRegistry().stream()
-            .filter(record -> record.getPubKey().equals(pubKey))
+            .filter(record -> record.getPubKey().equals(blsCredentials.getPubkey()))
             .findFirst();
     if (!validatorRecordOptional.isPresent()) {
       return Optional.empty();
@@ -209,7 +204,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
           new BeaconChainAttesterImpl(specHelpers, specHelpers.getChainSpec());
       validatorService =
           new BeaconChainValidator(
-              pubKey, proposer, attester, specHelpers, signer, observablePublisher, schedulers);
+              blsCredentials, proposer, attester, specHelpers, observablePublisher, schedulers);
       validatorService.start();
       changeCurrentStage(RegistrationStage.COMPLETE);
     }
@@ -239,7 +234,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
                                   getLatestState().getValidatorRegistry().stream()
                                       .filter(
                                           record -> {
-                                            return record.getPubKey().equals(pubKey);
+                                            return record.getPubKey().equals(blsCredentials.getPubkey());
                                           })
                                       .findFirst()
                                       .get();
@@ -257,7 +252,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
 
   private Optional<Deposit> onDeposit(Deposit deposit) {
     return Optional.of(deposit)
-        .filter(d -> d.getDepositData().getDepositInput().getPubKey().equals(pubKey));
+        .filter(d -> d.getDepositData().getDepositInput().getPubKey().equals(blsCredentials.getPubkey()));
   }
 
   private CompletableFuture<TransactionGateway.TxStatus> submitDeposit(
@@ -274,7 +269,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
     // object.
     //    Set deposit_input.proof_of_possession = EMPTY_SIGNATURE.
     DepositInput preDepositInput =
-        new DepositInput(pubKey, withdrawalCredentials, BLSSignature.ZERO);
+        new DepositInput(blsCredentials.getPubkey(), withdrawalCredentials, BLSSignature.ZERO);
     // Let proof_of_possession be the result of bls_sign of the hash_tree_root(deposit_input) with
     // domain=DOMAIN_DEPOSIT.
     Hash32 hash = specHelpers.hash_tree_root(preDepositInput);
@@ -282,9 +277,9 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
     Bytes8 domain =
         specHelpers.get_domain(
             latestState.getForkData(), specHelpers.get_current_epoch(latestState), DEPOSIT);
-    BLSSignature signature = signer.sign(hash, domain);
+    BLSSignature signature = blsCredentials.getSigner().sign(hash, domain);
     // Set deposit_input.proof_of_possession = proof_of_possession.
-    DepositInput depositInput = new DepositInput(pubKey, withdrawalCredentials, signature);
+    DepositInput depositInput = new DepositInput(blsCredentials.getPubkey(), withdrawalCredentials, signature);
 
     return depositInput;
   }

--- a/start/common/src/main/java/org/ethereum/beacon/Launcher.java
+++ b/start/common/src/main/java/org/ethereum/beacon/Launcher.java
@@ -18,11 +18,8 @@ import org.ethereum.beacon.consensus.verifier.BeaconBlockVerifier;
 import org.ethereum.beacon.consensus.verifier.BeaconStateVerifier;
 import org.ethereum.beacon.consensus.verifier.VerificationResult;
 import org.ethereum.beacon.core.operations.Attestation;
-import org.ethereum.beacon.core.types.BLSPubkey;
-import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.crypto.BLS381;
 import org.ethereum.beacon.crypto.BLS381.KeyPair;
-import org.ethereum.beacon.crypto.MessageParameters;
 import org.ethereum.beacon.db.InMemoryDatabase;
 import org.ethereum.beacon.pow.DepositContract;
 import org.ethereum.beacon.pow.DepositContract.ChainStart;
@@ -30,6 +27,7 @@ import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.validator.BeaconChainProposer;
 import org.ethereum.beacon.validator.BeaconChainValidator;
 import org.ethereum.beacon.validator.attester.BeaconChainAttesterImpl;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
 import org.ethereum.beacon.validator.proposer.BeaconChainProposerImpl;
 import org.ethereum.beacon.wire.WireApi;
 import reactor.core.publisher.DirectProcessor;
@@ -125,12 +123,10 @@ public class Launcher {
         specHelpers.getChainSpec());
 
     beaconChainValidator = new BeaconChainValidator(
-        BLSPubkey.wrap(validatorSig.getPublic().getEncodedBytes()),
+        BLS381Credentials.createWithInsecureSigner(validatorSig),
         beaconChainProposer,
         beaconChainAttester,
         specHelpers,
-        (msgHash, domain) -> BLSSignature.wrap(
-            BLS381.sign(MessageParameters.create(msgHash, domain), validatorSig).getEncoded()),
         observableStateProcessor.getObservableStateStream(),
         schedulers);
     beaconChainValidator.start();

--- a/start/common/src/main/java/org/ethereum/beacon/MultiValidatorLauncher.java
+++ b/start/common/src/main/java/org/ethereum/beacon/MultiValidatorLauncher.java
@@ -1,0 +1,155 @@
+package org.ethereum.beacon;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.ethereum.beacon.chain.DefaultBeaconChain;
+import org.ethereum.beacon.chain.MutableBeaconChain;
+import org.ethereum.beacon.chain.ProposedBlockProcessor;
+import org.ethereum.beacon.chain.ProposedBlockProcessorImpl;
+import org.ethereum.beacon.chain.SlotTicker;
+import org.ethereum.beacon.chain.observer.ObservableStateProcessor;
+import org.ethereum.beacon.chain.observer.ObservableStateProcessorImpl;
+import org.ethereum.beacon.chain.storage.BeaconChainStorage;
+import org.ethereum.beacon.chain.storage.BeaconChainStorageFactory;
+import org.ethereum.beacon.consensus.SpecHelpers;
+import org.ethereum.beacon.consensus.transition.InitialStateTransition;
+import org.ethereum.beacon.consensus.transition.PerBlockTransition;
+import org.ethereum.beacon.consensus.transition.PerEpochTransition;
+import org.ethereum.beacon.consensus.transition.PerSlotTransition;
+import org.ethereum.beacon.consensus.verifier.BeaconBlockVerifier;
+import org.ethereum.beacon.consensus.verifier.BeaconStateVerifier;
+import org.ethereum.beacon.consensus.verifier.VerificationResult;
+import org.ethereum.beacon.core.operations.Attestation;
+import org.ethereum.beacon.crypto.BLS381.KeyPair;
+import org.ethereum.beacon.db.InMemoryDatabase;
+import org.ethereum.beacon.pow.DepositContract;
+import org.ethereum.beacon.pow.DepositContract.ChainStart;
+import org.ethereum.beacon.schedulers.Schedulers;
+import org.ethereum.beacon.validator.BeaconChainProposer;
+import org.ethereum.beacon.validator.MultiValidatorService;
+import org.ethereum.beacon.validator.ValidatorService;
+import org.ethereum.beacon.validator.attester.BeaconChainAttesterImpl;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
+import org.ethereum.beacon.validator.proposer.BeaconChainProposerImpl;
+import org.ethereum.beacon.wire.WireApi;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class MultiValidatorLauncher {
+  private final SpecHelpers specHelpers;
+  private final DepositContract depositContract;
+  private final List<KeyPair> validatorSigs;
+  private final WireApi wireApi;
+
+  InMemoryDatabase db;
+  BeaconChainStorage beaconChainStorage;
+  MutableBeaconChain beaconChain;
+  SlotTicker slotTicker;
+  ObservableStateProcessor observableStateProcessor;
+  BeaconChainProposer beaconChainProposer;
+  BeaconChainAttesterImpl beaconChainAttester;
+  ValidatorService beaconChainValidator;
+  BeaconChainStorageFactory storageFactory;
+  Schedulers schedulers;
+
+  public MultiValidatorLauncher(
+      SpecHelpers specHelpers,
+      DepositContract depositContract,
+      List<KeyPair> validatorSigs,
+      WireApi wireApi,
+      BeaconChainStorageFactory storageFactory,
+      Schedulers schedulers) {
+
+    this.specHelpers = specHelpers;
+    this.depositContract = depositContract;
+    this.validatorSigs = validatorSigs;
+    this.wireApi = wireApi;
+    this.storageFactory = storageFactory;
+    this.schedulers = schedulers;
+
+    if (depositContract != null) {
+      Mono.from(depositContract.getChainStartMono()).subscribe(this::chainStarted);
+    }
+  }
+
+  void chainStarted(ChainStart chainStartEvent) {
+    InitialStateTransition initialTransition = new InitialStateTransition(chainStartEvent, specHelpers);
+    PerSlotTransition perSlotTransition = new PerSlotTransition(specHelpers);
+    PerBlockTransition perBlockTransition = new PerBlockTransition(specHelpers);
+    PerEpochTransition perEpochTransition = new PerEpochTransition(specHelpers);
+
+    db = new InMemoryDatabase();
+    beaconChainStorage = storageFactory.create(db);
+
+    // TODO
+    BeaconBlockVerifier blockVerifier = (block, state) -> VerificationResult.PASSED;
+    // TODO
+    BeaconStateVerifier stateVerifier = (block, state) -> VerificationResult.PASSED;
+
+    beaconChain = new DefaultBeaconChain(
+        specHelpers,
+        initialTransition,
+        perSlotTransition,
+        perBlockTransition,
+        perEpochTransition,
+        blockVerifier,
+        stateVerifier,
+        beaconChainStorage,
+        schedulers);
+    beaconChain.init();
+
+    slotTicker =
+        new SlotTicker(specHelpers, beaconChain.getRecentlyProcessed().getState(), schedulers);
+    slotTicker.start();
+
+    DirectProcessor<Attestation> allAttestations = DirectProcessor.create();
+    Flux.from(wireApi.inboundAttestationsStream())
+        .publishOn(schedulers.reactorEvents())
+        .subscribe(allAttestations);
+
+    observableStateProcessor = new ObservableStateProcessorImpl(
+        beaconChainStorage,
+        slotTicker.getTickerStream(),
+        allAttestations,
+        beaconChain.getBlockStatesStream(),
+        specHelpers,
+        perSlotTransition,
+        perEpochTransition,
+        schedulers);
+    observableStateProcessor.start();
+
+    beaconChainProposer = new BeaconChainProposerImpl(specHelpers,
+        specHelpers.getChainSpec(), perBlockTransition, perEpochTransition, depositContract);
+    beaconChainAttester = new BeaconChainAttesterImpl(specHelpers,
+        specHelpers.getChainSpec());
+
+    List<BLS381Credentials> credentials =
+        validatorSigs.stream()
+            .map(BLS381Credentials::createWithInsecureSigner)
+            .collect(Collectors.toList());
+
+    beaconChainValidator = new MultiValidatorService(
+        credentials,
+        beaconChainProposer,
+        beaconChainAttester,
+        specHelpers,
+        observableStateProcessor.getObservableStateStream(),
+        schedulers);
+    beaconChainValidator.start();
+
+    ProposedBlockProcessor proposedBlocksProcessor = new ProposedBlockProcessorImpl(
+        beaconChain, schedulers);
+    Flux.from(beaconChainValidator.getProposedBlocksStream())
+        .subscribe(proposedBlocksProcessor::newBlockProposed);
+    Flux.from(proposedBlocksProcessor.processedBlocksStream())
+        .subscribe(wireApi::sendProposedBlock);
+
+    Flux.from(beaconChainValidator.getAttestationsStream()).subscribe(wireApi::sendAttestation);
+    Flux.from(beaconChainValidator.getAttestationsStream()).subscribe(allAttestations);
+
+    Flux.from(wireApi.inboundBlocksStream())
+        .publishOn(schedulers.reactorEvents())
+        .subscribe(beaconChain::insert);
+  }
+}

--- a/start/common/src/test/java/org/ethereum/beacon/LocalMultiValidatorTest.java
+++ b/start/common/src/test/java/org/ethereum/beacon/LocalMultiValidatorTest.java
@@ -1,0 +1,153 @@
+package org.ethereum.beacon;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import org.ethereum.beacon.chain.storage.impl.MemBeaconChainStorageFactory;
+import org.ethereum.beacon.consensus.SpecHelpers;
+import org.ethereum.beacon.consensus.TestUtils;
+import org.ethereum.beacon.core.operations.Deposit;
+import org.ethereum.beacon.core.spec.ChainSpec;
+import org.ethereum.beacon.core.state.Eth1Data;
+import org.ethereum.beacon.core.types.SlotNumber;
+import org.ethereum.beacon.core.types.Time;
+import org.ethereum.beacon.core.types.ValidatorIndex;
+import org.ethereum.beacon.crypto.BLS381.KeyPair;
+import org.ethereum.beacon.pow.DepositContract;
+import org.ethereum.beacon.pow.DepositContract.ChainStart;
+import org.ethereum.beacon.schedulers.ControlledSchedulers;
+import org.ethereum.beacon.schedulers.LoggerMDCExecutor;
+import org.ethereum.beacon.schedulers.Schedulers;
+import org.ethereum.beacon.wire.LocalWireHub;
+import org.ethereum.beacon.wire.WireApi;
+import org.javatuples.Pair;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import tech.pegasys.artemis.ethereum.core.Hash32;
+import tech.pegasys.artemis.util.uint.UInt64;
+
+public class LocalMultiValidatorTest {
+
+  private static class SimpleDepositContract implements DepositContract {
+    private final ChainStart chainStart;
+
+    public SimpleDepositContract(ChainStart chainStart) {
+      this.chainStart = chainStart;
+    }
+
+    @Override
+    public Publisher<ChainStart> getChainStartMono() {
+      return Mono.just(chainStart);
+    }
+
+    @Override
+    public Publisher<Deposit> getDepositStream() {
+      return Mono.empty();
+    }
+
+    @Override
+    public List<DepositInfo> peekDeposits(int maxCount, Eth1Data fromDepositExclusive,
+        Eth1Data tillDepositInclusive) {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean hasDepositRoot(Hash32 blockHash, Hash32 depositRoot) {
+      return true;
+    }
+
+    @Override
+    public Optional<Eth1Data> getLatestEth1Data() {
+      return Optional.of(chainStart.getEth1Data());
+    }
+
+    @Override
+    public void setDistanceFromHead(long distanceFromHead) {}
+  }
+
+  public static void main(String[] args) throws Exception {
+    int validatorCount = 4;
+    int epochLength = 2;
+    Random rnd = new Random(1);
+    Time genesisTime = Time.of(10 * 60);
+
+    Eth1Data eth1Data = new Eth1Data(Hash32.random(rnd), Hash32.random(rnd));
+
+    ChainSpec chainSpec =
+        new ChainSpec() {
+          @Override
+          public SlotNumber.EpochLength getEpochLength() {
+            return new SlotNumber.EpochLength(UInt64.valueOf(epochLength));
+          }
+          @Override
+          public Time getSlotDuration() {
+            return Time.of(10);
+          }
+
+          @Override
+          public SlotNumber getGenesisSlot() {
+            return SlotNumber.of(1_000_000);
+          }
+
+          @Override
+          public ValidatorIndex getTargetCommitteeSize() {
+            return ValidatorIndex.of(1);
+          }
+
+          @Override
+          public SlotNumber getMinAttestationInclusionDelay() {
+            return SlotNumber.of(1);
+          }
+        };
+
+    Pair<List<Deposit>, List<KeyPair>> anyDeposits = TestUtils.getAnyDeposits(
+        SpecHelpers.createWithSSZHasher(chainSpec, () -> 0L), validatorCount);
+    List<Deposit> deposits = anyDeposits.getValue0();
+
+    LocalWireHub localWireHub = new LocalWireHub(s -> {});
+    ChainStart chainStart = new ChainStart(genesisTime, eth1Data, deposits);
+    DepositContract depositContract = new SimpleDepositContract(chainStart);
+
+    System.out.println("Start multi validator service...");
+    ControlledSchedulers schedulers = Schedulers.createControlled();
+    schedulers.setCurrentTime(genesisTime.getMillis().getValue() + 1000);
+    SpecHelpers specHelpers = SpecHelpers
+        .createWithSSZHasher(chainSpec, schedulers::getCurrentTime);
+    WireApi wireApi = localWireHub.createNewPeer("multi-peer");
+
+    MultiValidatorLauncher launcher =
+        new MultiValidatorLauncher(
+            specHelpers,
+            depositContract,
+            anyDeposits.getValue1(),
+            wireApi,
+            new MemBeaconChainStorageFactory(),
+            schedulers);
+
+    Flux.from(launcher.slotTicker.getTickerStream())
+        .subscribe(slot -> System.out.println("Slot: " + slot.toString(chainSpec, genesisTime)));
+    Flux.from(launcher.observableStateProcessor.getObservableStateStream())
+        .subscribe(os -> {
+          System.out.println("New observable state: " + os.toString(specHelpers));
+        });
+    Flux.from(launcher.beaconChainValidator.getProposedBlocksStream())
+        .subscribe(block ->System.out.println(" !!!New block: " +
+            block.toString(chainSpec, genesisTime, specHelpers::hash_tree_root)));
+    Flux.from(launcher.beaconChainValidator.getAttestationsStream())
+        .subscribe(attest ->System.out.println(" !!!New attestation: " +
+            attest.toString(chainSpec, genesisTime)));
+    Flux.from(launcher.beaconChain.getBlockStatesStream())
+        .subscribe(blockState ->System.out.println("Block imported: " +
+            blockState.getBlock().toString(chainSpec, genesisTime, specHelpers::hash_tree_root)));
+    System.out.println("Multi validator started");
+
+    while (true) {
+      System.out.println("===============================");
+      schedulers.addTime(Duration.ofSeconds(10));
+    }
+  }
+}

--- a/util/src/main/java/org/ethereum/beacon/schedulers/LatestExecutor.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/LatestExecutor.java
@@ -1,0 +1,56 @@
+package org.ethereum.beacon.schedulers;
+
+import java.util.function.Consumer;
+
+/**
+ * Processes events submitted via {@link #newEvent(T)} with the specified
+ * <code>eventProcessor</code> on the specified <code>scheduler</code>.
+ *
+ * Guarantees that the latest event would be processed, though other
+ * intermediate events could be skipped.
+ *
+ * Skips subsequent events if any previous is still processing.
+ * Avoids creating scheduling a task for each event thus allowing frequent
+ * events submitting.
+ */
+public class LatestExecutor<T> {
+  private final Scheduler scheduler;
+  private final Consumer<T> eventProcessor;
+  private T latestEvent = null;
+  private boolean processingEvent;
+
+  public LatestExecutor(Scheduler scheduler, Consumer<T> eventProcessor) {
+    this.scheduler = scheduler;
+    this.eventProcessor = eventProcessor;
+  }
+
+  /**
+   * Submits a new event for processing.
+   * This particular event may not be processed if a subsequent event submitted
+   * shortly
+   */
+  public synchronized void newEvent(T event) {
+    latestEvent = event;
+    startEvent();
+  }
+
+  private synchronized void startEvent() {
+    if (!processingEvent) {
+      if (latestEvent != null) {
+        T event = latestEvent;
+        latestEvent = null;
+
+        processingEvent = true;
+        scheduler.execute(() -> runEvent(event));
+      }
+    }
+  }
+
+  private void runEvent(T event) {
+    eventProcessor.accept(event);
+    synchronized (this) {
+      processingEvent = false;
+    }
+    startEvent();
+  }
+}

--- a/util/src/test/java/org/ethereum/beacon/schedulers/LatestExecutorTest.java
+++ b/util/src/test/java/org/ethereum/beacon/schedulers/LatestExecutorTest.java
@@ -1,0 +1,76 @@
+package org.ethereum.beacon.schedulers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LatestExecutorTest {
+
+  @Test
+  public void test1() throws InterruptedException {
+    AtomicInteger tasksCounter = new AtomicInteger();
+    ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1) {
+      @Override
+      protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable,
+          RunnableScheduledFuture<V> task) {
+        tasksCounter.incrementAndGet();
+        return super.decorateTask(runnable, task);
+      }
+
+      @Override
+      protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable,
+          RunnableScheduledFuture<V> task) {
+        tasksCounter.incrementAndGet();
+        return super.decorateTask(callable, task);
+      }
+    };
+    ExecutorScheduler scheduler = new ExecutorScheduler(executor);
+
+    List<Integer> processedEvents = new ArrayList<>();
+    LatestExecutor<Integer> latestExecutor = new LatestExecutor<>(scheduler, i -> {
+      processedEvents.add(i);
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    });
+
+    for (int i = 0; i < 100; i++) {
+      latestExecutor.newEvent(i);
+    }
+    Thread.sleep(300);
+
+    Assert.assertEquals(99, (int) processedEvents.get(processedEvents.size() - 1));
+    Assert.assertTrue(processedEvents.size() < 3);
+    Assert.assertTrue(tasksCounter.get() < 3);
+
+    processedEvents.clear();
+    tasksCounter.set(0);
+
+    latestExecutor.newEvent(200);
+    Thread.sleep(200);
+
+    Assert.assertEquals(200, (int) processedEvents.get(0));
+    Assert.assertTrue(processedEvents.size() == 1);
+    Assert.assertTrue(tasksCounter.get() == 1);
+
+    processedEvents.clear();
+    tasksCounter.set(0);
+
+    latestExecutor.newEvent(300);
+    Thread.sleep(10);
+    latestExecutor.newEvent(301);
+
+    Thread.sleep(300);
+
+    Assert.assertEquals(301, (int) processedEvents.get(processedEvents.size() - 1));
+    Assert.assertTrue(processedEvents.size() < 3);
+    Assert.assertTrue(tasksCounter.get() < 3);
+  }
+}

--- a/validator/src/main/java/org/ethereum/beacon/validator/MultiValidatorService.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/MultiValidatorService.java
@@ -102,7 +102,7 @@ public class MultiValidatorService implements ValidatorService {
             .name("BeaconChainValidator.attestation");
 
     executor = this.schedulers.newSingleThreadDaemon("validator-service");
-    initExecutor = new LatestExecutor<>(schedulers.cpuHeavy(), this::initFromLatestBeaconState);
+    initExecutor = new LatestExecutor<>(schedulers.blocking(), this::initFromLatestBeaconState);
   }
 
   @Override

--- a/validator/src/main/java/org/ethereum/beacon/validator/MultiValidatorService.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/MultiValidatorService.java
@@ -1,0 +1,393 @@
+package org.ethereum.beacon.validator;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.chain.observer.ObservableBeaconState;
+import org.ethereum.beacon.consensus.SpecHelpers;
+import org.ethereum.beacon.core.BeaconBlock;
+import org.ethereum.beacon.core.BeaconState;
+import org.ethereum.beacon.core.operations.Attestation;
+import org.ethereum.beacon.core.state.ShardCommittee;
+import org.ethereum.beacon.core.types.BLSPubkey;
+import org.ethereum.beacon.core.types.SlotNumber;
+import org.ethereum.beacon.core.types.Time;
+import org.ethereum.beacon.core.types.ValidatorIndex;
+import org.ethereum.beacon.schedulers.RunnableEx;
+import org.ethereum.beacon.schedulers.Scheduler;
+import org.ethereum.beacon.schedulers.Schedulers;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+
+/** Runs several validators in one instance. */
+public class MultiValidatorService implements ValidatorService {
+
+  private static final Logger logger = LogManager.getLogger(MultiValidatorService.class);
+
+  private final Schedulers schedulers;
+
+  private final DirectProcessor<BeaconBlock> blocksSink = DirectProcessor.create();
+  private final Publisher<BeaconBlock> blocksStream;
+
+  private final DirectProcessor<Attestation> attestationsSink = DirectProcessor.create();
+  private final Publisher<Attestation> attestationsStream;
+
+  /** Proposer logic. */
+  private BeaconChainProposer proposer;
+  /** Attester logic. */
+  private BeaconChainAttester attester;
+  /** The spec. */
+  private SpecHelpers specHelpers;
+
+  private Publisher<ObservableBeaconState> stateStream;
+
+  /** Credentials of yet not initialized validators. */
+  private Map<BLSPubkey, BLS381Credentials> uninitialized;
+  /** Credentials of already initialized validators. */
+  private Map<ValidatorIndex, BLS381Credentials> initialized = new ConcurrentHashMap<>();
+  /** Latest slot that has been processed. Initialized in {@link #init(BeaconState)} method. */
+  private SlotNumber lastProcessedSlot = SlotNumber.ZERO;
+  /** The most recent beacon state came from the outside. */
+  private ObservableBeaconState recentState;
+
+  /** Validator task executor. */
+  private final Scheduler executor;
+
+  /** Validator init executor with capacity of the queue = 1. */
+  private final BlockingQueue<Runnable> initQueue = new ArrayBlockingQueue<>(1);
+
+  private final ExecutorService initExecutor;
+
+  public MultiValidatorService(
+      List<BLS381Credentials> blsCredentials,
+      BeaconChainProposer proposer,
+      BeaconChainAttester attester,
+      SpecHelpers specHelpers,
+      Publisher<ObservableBeaconState> stateStream,
+      Schedulers schedulers) {
+    this.uninitialized =
+        blsCredentials.stream()
+            .collect(Collectors.toMap(BLS381Credentials::getPubkey, Function.identity()));
+    this.proposer = proposer;
+    this.attester = attester;
+    this.specHelpers = specHelpers;
+    this.stateStream = stateStream;
+    this.schedulers = schedulers;
+
+    blocksStream =
+        Flux.from(blocksSink)
+            .publishOn(this.schedulers.reactorEvents())
+            .onBackpressureError()
+            .name("BeaconChainValidator.block");
+
+    attestationsStream =
+        Flux.from(attestationsSink)
+            .publishOn(this.schedulers.reactorEvents())
+            .onBackpressureError()
+            .name("BeaconChainValidator.attestation");
+
+    executor = this.schedulers.newSingleThreadDaemon("validator-service");
+    initExecutor =
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            initQueue,
+            new ThreadFactoryBuilder()
+                .setNameFormat("multi-validator-init-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(
+                    (thread, t) -> logger.error("Failed to execute init", t))
+                .build());
+  }
+
+  @Override
+  public void start() {
+    subscribeToStateUpdates(this::onNewState);
+  }
+
+  @Override
+  public void stop() {}
+
+  /**
+   * Passes validators from {@link #uninitialized} map through initialization process.
+   *
+   * @param state a state object to seek for validators in.
+   */
+  void init(BeaconState state) {
+    initQueue.clear();
+    initExecutor.submit(
+        () -> {
+          Map<ValidatorIndex, BLS381Credentials> intoCommittees = new HashMap<>();
+          for (ValidatorIndex i : state.getValidatorRegistry().size()) {
+            BLS381Credentials credentials =
+                uninitialized.remove(state.getValidatorRegistry().get(i).getPubKey());
+            if (credentials != null) {
+              intoCommittees.put(i, credentials);
+            }
+          }
+          this.initialized.putAll(intoCommittees);
+
+          if (!intoCommittees.isEmpty())
+            logger.info("initialized validators: {}", intoCommittees.keySet());
+        });
+  }
+
+  /**
+   * Keeps the most recent state in memory.
+   *
+   * <p>Recent state is required by delayed tasks like {@link #attest(ValidatorIndex)}.
+   *
+   * @param state state came from the outside.
+   */
+  private void keepRecentState(ObservableBeaconState state) {
+    this.recentState = state;
+  }
+
+  /**
+   * Connects outer state updates with validator behaviour. Is triggered on each new state received
+   * from the outside.
+   *
+   * <p>It is assumed that outer component, that validator is subscribed to, sends a new state on
+   * every processed and on every empty slot transition made on top of the chain head. * *
+   *
+   * <p><strong>Note:</strong> coming state is discarded if it isn't related to current slot.
+   *
+   * @param observableState a new state object.
+   */
+  @VisibleForTesting
+  void onNewState(ObservableBeaconState observableState) {
+    if (isCurrentSlot(observableState.getLatestSlotState())) {
+      keepRecentState(observableState);
+      processState(observableState);
+    }
+  }
+
+  /**
+   * Processes a new state.
+   *
+   * <p>Initializes service if it's possible and then runs validator tasks by calling to {@link
+   * #runTasks(ObservableBeaconState)}.
+   *
+   * @param observableState a state object to process.
+   */
+  private void processState(ObservableBeaconState observableState) {
+    BeaconState state = observableState.getLatestSlotState();
+
+    if (!isSlotProcessed(state)) {
+      setSlotProcessed(state);
+      if (!isInitialized()) {
+        init(state);
+      }
+      runTasks(observableState);
+    }
+  }
+
+  /**
+   * Checks if any of {@link #initialized} validators are assigned to either propose or attest to a
+   * block with slot equal to {@code observableState.slot}. And triggers corresponding routine:
+   *
+   * <ul>
+   *   <li>{@link #propose(ValidatorIndex, ObservableBeaconState)} routine is triggered instantly
+   *       with received {@code observableState} object.
+   *   <li>{@link #attest(ValidatorIndex)} routine is a delayed task, it's called with {@link
+   *       #recentState} object.
+   * </ul>
+   *
+   * @param observableState a state that validator tasks are executed with.
+   */
+  @VisibleForTesting
+  void runTasks(final ObservableBeaconState observableState) {
+    BeaconState state = observableState.getLatestSlotState();
+
+    // trigger proposer
+    ValidatorIndex proposerIndex = specHelpers.get_beacon_proposer_index(state, state.getSlot());
+    if (initialized.containsKey(proposerIndex)) {
+      runAsync(() -> propose(proposerIndex, observableState));
+    }
+
+    // trigger attester at a halfway through the slot
+    Time startAt = specHelpers.get_slot_middle_time(state, state.getSlot());
+    List<ShardCommittee> committees =
+        specHelpers.get_crosslink_committees_at_slot(state, state.getSlot());
+    for (ShardCommittee sc : committees) {
+      sc.getCommittee().stream()
+          .filter(initialized::containsKey)
+          .forEach(index -> schedule(startAt, () -> this.attest(index)));
+    }
+  }
+
+  /**
+   * Runs a routine asynchronously using {@link #executor}.
+   *
+   * @param routine a routine.
+   */
+  private void runAsync(RunnableEx routine) {
+    executor.execute(routine);
+  }
+
+  /**
+   * Schedules a routine for a point in the future.
+   *
+   * @param startAt a unix timestamp of start point, in seconds.
+   * @param routine a routine.
+   */
+  private void schedule(Time startAt, RunnableEx routine) {
+    long startAtMillis = startAt.getValue() * 1000;
+    assert schedulers.getCurrentTime() < startAtMillis;
+    executor.executeWithDelay(
+        Duration.ofMillis(schedulers.getCurrentTime() - startAtMillis), routine);
+  }
+
+  /**
+   * Proposes a new block that is build on top of given state.
+   *
+   * @param index index of proposer.
+   * @param observableState a state.
+   */
+  private void propose(ValidatorIndex index, final ObservableBeaconState observableState) {
+    BLS381Credentials credentials = initialized.get(index);
+    if (credentials != null) {
+      BeaconBlock newBlock = proposer.propose(observableState, credentials.getSigner());
+      propagateBlock(newBlock);
+
+      logger.info(
+          "validator {}: proposed a {}",
+          index,
+          newBlock.toString(
+              specHelpers.getChainSpec(),
+              observableState.getLatestSlotState().getGenesisTime(),
+              specHelpers::hash_tree_root));
+    }
+  }
+
+  /**
+   * Attests to a head block of {@link #recentState}.
+   *
+   * <p><strong>Note:</strong> since {@link #recentState} may be updated after attestation has been
+   * scheduled, there is a sanity check that validator is still eligible to attest with {@link
+   * #recentState}.
+   *
+   * @param index index of attester.
+   */
+  private void attest(ValidatorIndex index) {
+    final ObservableBeaconState observableState = this.recentState;
+    final BeaconState state = observableState.getLatestSlotState();
+
+    Optional<ShardCommittee> validatorCommittee = getValidatorCommittee(index, state);
+    BLS381Credentials credentials = initialized.get(index);
+    if (validatorCommittee.isPresent() && credentials != null) {
+      Attestation attestation =
+          attester.attest(
+              index, validatorCommittee.get().getShard(), observableState, credentials.getSigner());
+      propagateAttestation(attestation);
+
+      logger.info(
+          "validator {}: attested to head: {} in a slot: {}",
+          index,
+          observableState
+              .getHead()
+              .toString(
+                  specHelpers.getChainSpec(),
+                  observableState.getLatestSlotState().getGenesisTime(),
+                  specHelpers::hash_tree_root),
+          state.getSlot());
+    }
+  }
+
+  /**
+   * Marks a slot of the state as a processed one.
+   *
+   * <p>Used by {@link #isSlotProcessed(BeaconState)} as a part of re-play protection.
+   *
+   * @param state a state.
+   */
+  private void setSlotProcessed(BeaconState state) {
+    this.lastProcessedSlot = state.getSlot();
+  }
+
+  /** Returns committee where the validator participates if any */
+  private Optional<ShardCommittee> getValidatorCommittee(ValidatorIndex index, BeaconState state) {
+    List<ShardCommittee> committees =
+        specHelpers.get_crosslink_committees_at_slot(state, state.getSlot());
+    return committees.stream().filter(sc -> sc.getCommittee().contains(index)).findFirst();
+  }
+
+  /**
+   * Checks whether slot of the state was already processed.
+   *
+   * <p>Processed slot means that tasks for this particular slot has already been initiated. Calling
+   * to this method protects from slashing condition violation when tasks for same slot could be
+   * initiated more than once due to chain re-orgs.
+   *
+   * @param state a state.
+   * @return {@code true} if slot has been processed, {@link false} otherwise.
+   */
+  private boolean isSlotProcessed(BeaconState state) {
+    return state.getSlot().lessEqual(lastProcessedSlot);
+  }
+
+  /**
+   * Whether current moment in time belongs to a slot of the state.
+   *
+   * @param state a state.
+   * @return {@link true} if current moment belongs to a slot, {@link false} otherwise.
+   */
+  private boolean isCurrentSlot(BeaconState state) {
+    return specHelpers.is_current_slot(state);
+  }
+
+  /**
+   * Whether validator's index has already been found in the recently processed state.
+   *
+   * @return {@code true} if index is defined, {@code false} otherwise.
+   */
+  private boolean isInitialized() {
+    return uninitialized.isEmpty();
+  }
+
+  private void propagateBlock(BeaconBlock newBlock) {
+    blocksSink.onNext(newBlock);
+  }
+
+  private void propagateAttestation(Attestation attestation) {
+    attestationsSink.onNext(attestation);
+  }
+
+  private void subscribeToStateUpdates(Consumer<ObservableBeaconState> payload) {
+    Flux.from(stateStream).subscribe(payload);
+  }
+
+  @VisibleForTesting
+  ObservableBeaconState getRecentState() {
+    return recentState;
+  }
+
+  @Override
+  public Publisher<BeaconBlock> getProposedBlocksStream() {
+    return blocksStream;
+  }
+
+  @Override
+  public Publisher<Attestation> getAttestationsStream() {
+    return attestationsStream;
+  }
+}

--- a/validator/src/main/java/org/ethereum/beacon/validator/crypto/BLS381Credentials.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/crypto/BLS381Credentials.java
@@ -3,6 +3,8 @@ package org.ethereum.beacon.validator.crypto;
 import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.crypto.BLS381;
+import org.ethereum.beacon.crypto.BLS381.PrivateKey;
+import tech.pegasys.artemis.util.bytes.Bytes32;
 
 /** A pair of {@link BLS381MessageSigner} instance and a corresponding pubkey. */
 public class BLS381Credentials {
@@ -26,6 +28,16 @@ public class BLS381Credentials {
     BLSPubkey pubkey = BLSPubkey.wrap(keyPair.getPublic().getEncodedBytes());
     BLS381MessageSigner signer =
         new InsecureBLS381MessageSigner(keyPair.getPrivate().getEncodedBytes());
+    return new BLS381Credentials(pubkey, signer);
+  }
+
+  public static BLS381Credentials createWithInsecureSigner(Bytes32 privateKeyBytes) {
+    BLSPubkey pubkey =
+        BLSPubkey.wrap(
+            BLS381.KeyPair.create(PrivateKey.create(privateKeyBytes))
+                .getPublic()
+                .getEncodedBytes());
+    BLS381MessageSigner signer = new InsecureBLS381MessageSigner(privateKeyBytes);
     return new BLS381Credentials(pubkey, signer);
   }
 }

--- a/validator/src/main/java/org/ethereum/beacon/validator/crypto/BLS381Credentials.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/crypto/BLS381Credentials.java
@@ -1,0 +1,31 @@
+package org.ethereum.beacon.validator.crypto;
+
+import org.ethereum.beacon.core.types.BLSPubkey;
+import org.ethereum.beacon.core.types.BLSSignature;
+import org.ethereum.beacon.crypto.BLS381;
+
+/** A pair of {@link BLS381MessageSigner} instance and a corresponding pubkey. */
+public class BLS381Credentials {
+  private final BLSPubkey pubkey;
+  private final MessageSigner<BLSSignature> signer;
+
+  public BLS381Credentials(BLSPubkey pubkey, MessageSigner<BLSSignature> signer) {
+    this.pubkey = pubkey;
+    this.signer = signer;
+  }
+
+  public BLSPubkey getPubkey() {
+    return pubkey;
+  }
+
+  public MessageSigner<BLSSignature> getSigner() {
+    return signer;
+  }
+
+  public static BLS381Credentials createWithInsecureSigner(BLS381.KeyPair keyPair) {
+    BLSPubkey pubkey = BLSPubkey.wrap(keyPair.getPublic().getEncodedBytes());
+    BLS381MessageSigner signer =
+        new InsecureBLS381MessageSigner(keyPair.getPrivate().getEncodedBytes());
+    return new BLS381Credentials(pubkey, signer);
+  }
+}

--- a/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/util/ValidatorServiceTestUtil.java
@@ -17,6 +17,7 @@ import org.ethereum.beacon.validator.BeaconChainAttester;
 import org.ethereum.beacon.validator.BeaconChainProposer;
 import org.ethereum.beacon.validator.BeaconChainValidator;
 import org.ethereum.beacon.validator.attester.BeaconChainAttesterTestUtil;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
 import org.ethereum.beacon.validator.crypto.MessageSigner;
 import org.ethereum.beacon.validator.proposer.BeaconChainProposerTestUtil;
 import org.mockito.Mockito;
@@ -41,8 +42,10 @@ public abstract class ValidatorServiceTestUtil {
     BeaconChainAttester attester = BeaconChainAttesterTestUtil.mockAttester(specHelpers);
     MessageSigner<BLSSignature> signer = MessageSignerTestUtil.createBLSSigner();
 
+    BLS381Credentials blsCredentials = new BLS381Credentials(pubkey, signer);
+
     return Mockito.spy(
-        new BeaconChainValidator(pubkey, proposer, attester, specHelpers,
-            signer, Mono.empty(), Schedulers.createDefault()));
+        new BeaconChainValidator(blsCredentials, proposer, attester, specHelpers,
+            Mono.empty(), Schedulers.createDefault()));
   }
 }


### PR DESCRIPTION
### What's done
A service that able to carry `N` validators in one instance. 
An implementation is simply a copy&paste of `BeaconChainValidator` code adopted for a multi-validator case. As these two classes has a lot in common, it could be moved to some `AbstractValidatorService` later on, if needed.