### PR TITLE
ssz signed_root added to ssz hasher + used where needed

### DIFF
--- a/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/SpecHelpers.java
@@ -1,22 +1,5 @@
 package org.ethereum.beacon.consensus;
 
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-import static java.util.stream.Collectors.toList;
-import static org.ethereum.beacon.core.spec.SignatureDomains.ATTESTATION;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import javax.annotation.Nonnull;
 import org.ethereum.beacon.consensus.hasher.ObjectHasher;
 import org.ethereum.beacon.consensus.hasher.SSZObjectHasher;
 import org.ethereum.beacon.core.BeaconBlock;
@@ -48,7 +31,6 @@ import org.ethereum.beacon.crypto.BLS381.PublicKey;
 import org.ethereum.beacon.crypto.BLS381.Signature;
 import org.ethereum.beacon.crypto.Hashes;
 import org.ethereum.beacon.crypto.MessageParameters;
-import org.ethereum.beacon.schedulers.Schedulers;
 import tech.pegasys.artemis.ethereum.core.Hash32;
 import tech.pegasys.artemis.util.bytes.Bytes3;
 import tech.pegasys.artemis.util.bytes.Bytes32;
@@ -58,6 +40,23 @@ import tech.pegasys.artemis.util.bytes.BytesValue;
 import tech.pegasys.artemis.util.collections.ReadList;
 import tech.pegasys.artemis.util.uint.UInt64;
 import tech.pegasys.artemis.util.uint.UInt64s;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.lang.Math.min;
+import static java.util.stream.Collectors.toList;
+import static org.ethereum.beacon.core.spec.SignatureDomains.ATTESTATION;
 
 /**
  * https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#helper-functions
@@ -607,7 +606,7 @@ public class SpecHelpers {
 
     return bls_verify(
         pubkey,
-        hash_tree_root(deposit_input),
+        signed_root(deposit_input, "proofOfPossession"),
         proof_of_possession,
         get_domain(state.getForkData(), get_current_epoch(state), SignatureDomains.DEPOSIT));
   }
@@ -1007,8 +1006,14 @@ public class SpecHelpers {
     }
   }
 
+  /** Function for hashing objects into a single root utilizing a hash tree structure */
   public Hash32 hash_tree_root(Object object) {
     return objectHasher.getHash(object);
+  }
+
+  /** Function for hashing objects with part starting from field rejected */
+  public Hash32 signed_root(Object object, String field) {
+    return objectHasher.getHashTruncate(object, field);
   }
 
   /*

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/hasher/ObjectHasher.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/hasher/ObjectHasher.java
@@ -12,6 +12,10 @@ import tech.pegasys.artemis.util.bytes.BytesValue;
  */
 public interface ObjectHasher<H extends BytesValue> {
 
+  static ObjectHasher<Hash32> createSSZOverKeccak256() {
+    return SSZObjectHasher.create(Hashes::keccak256);
+  }
+
   /**
    * Calculates hash of given object.
    *
@@ -20,7 +24,12 @@ public interface ObjectHasher<H extends BytesValue> {
    */
   H getHash(Object input);
 
-  static ObjectHasher<Hash32> createSSZOverKeccak256() {
-    return SSZObjectHasher.create(Hashes::keccak256);
-  }
+  /**
+   * Calculates hash of object truncated from current to `field` (not included).
+   *
+   * @param input an object of any type.
+   * @param field this and all subsequent fields will not be included in hashed object
+   * @return calculated hash.
+   */
+  H getHashTruncate(Object input, String field);
 }

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/block/ProposerSignatureVerifier.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/block/ProposerSignatureVerifier.java
@@ -1,18 +1,18 @@
 package org.ethereum.beacon.consensus.verifier.block;
 
-import static org.ethereum.beacon.core.spec.SignatureDomains.PROPOSAL;
-
 import org.ethereum.beacon.consensus.SpecHelpers;
 import org.ethereum.beacon.consensus.verifier.BeaconBlockVerifier;
 import org.ethereum.beacon.consensus.verifier.VerificationResult;
 import org.ethereum.beacon.core.BeaconBlock;
 import org.ethereum.beacon.core.BeaconState;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.ValidatorIndex;
 import tech.pegasys.artemis.ethereum.core.Hash32;
 import tech.pegasys.artemis.util.bytes.Bytes8;
+
+import static org.ethereum.beacon.core.spec.SignatureDomains.PROPOSAL;
 
 /**
  * Verifies proposer signature of the block.
@@ -34,17 +34,15 @@ public class ProposerSignatureVerifier implements BeaconBlockVerifier {
   @Override
   public VerificationResult verify(BeaconBlock block, BeaconState state) {
 
-    // Let block_without_signature_root be the hash_tree_root of block where block.signature is set to EMPTY_SIGNATURE.
-    BeaconBlock blockWithoutSignature = block.withoutSignature();
-
     // Let proposal_root = hash_tree_root(
-    //  ProposalSignedData(state.slot, BEACON_CHAIN_SHARD_NUMBER, block_without_signature_root)).
-    ProposalSignedData proposal =
-        new ProposalSignedData(
+    //  Proposal(state.slot, BEACON_CHAIN_SHARD_NUMBER, block_without_signature_root)).
+    Proposal proposal =
+        new Proposal(
             state.getSlot(),
             chainSpec.getBeaconChainShardNumber(),
-            specHelpers.hash_tree_root(blockWithoutSignature));
-    Hash32 proposalRoot = specHelpers.hash_tree_root(proposal);
+            specHelpers.signed_root(block, "signature"),
+            block.getSignature());
+    Hash32 proposalRoot = specHelpers.signed_root(proposal, "signature");
 
     // Verify that bls_verify(
     //  pubkey=state.validator_registry[get_beacon_proposer_index(state, state.slot)].pubkey,
@@ -53,10 +51,10 @@ public class ProposerSignatureVerifier implements BeaconBlockVerifier {
     //  domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_PROPOSAL)).
     ValidatorIndex proposerIndex = specHelpers.get_beacon_proposer_index(state, state.getSlot());
     BLSPubkey publicKey = state.getValidatorRegistry().get(proposerIndex).getPubKey();
-    Bytes8 domain = specHelpers.get_domain(state.getForkData(),
-        specHelpers.get_current_epoch(state), PROPOSAL);
+    Bytes8 domain =
+        specHelpers.get_domain(state.getForkData(), specHelpers.get_current_epoch(state), PROPOSAL);
 
-    if (specHelpers.bls_verify(publicKey, proposalRoot, block.getSignature(), domain)) {
+    if (specHelpers.bls_verify(publicKey, proposalRoot, proposal.getSignature(), domain)) {
       return VerificationResult.PASSED;
     } else {
       return VerificationResult.failedResult(

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/ExitVerifier.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/ExitVerifier.java
@@ -64,7 +64,7 @@ public class ExitVerifier implements OperationVerifier<Exit> {
     //    domain=get_domain(state.fork, exit.epoch, DOMAIN_EXIT)).
     if (!specHelpers.bls_verify(
         validator.getPubKey(),
-        specHelpers.hash_tree_root(new Exit(exit.getEpoch(), exit.getValidatorIndex(), BLSSignature.ZERO)),
+        specHelpers.signed_root(exit, "signature"),
         exit.getSignature(),
         specHelpers.get_domain(state.getForkData(), exit.getEpoch(), EXIT))) {
       return failedResult("failed to verify signature");

--- a/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/ProposerSlashingVerifier.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/verifier/operation/ProposerSlashingVerifier.java
@@ -30,27 +30,27 @@ public class ProposerSlashingVerifier implements OperationVerifier<ProposerSlash
   @Override
   public VerificationResult verify(ProposerSlashing proposerSlashing, BeaconState state) {
     specHelpers.checkIndexRange(state, proposerSlashing.getProposerIndex());
-    specHelpers.checkShardRange(proposerSlashing.getProposalData1().getShard());
-    specHelpers.checkShardRange(proposerSlashing.getProposalData2().getShard());
+    specHelpers.checkShardRange(proposerSlashing.getProposal1().getShard());
+    specHelpers.checkShardRange(proposerSlashing.getProposal2().getShard());
 
     if (!proposerSlashing
-        .getProposalData1()
+        .getProposal1()
         .getSlot()
-        .equals(proposerSlashing.getProposalData2().getSlot())) {
+        .equals(proposerSlashing.getProposal2().getSlot())) {
       return failedResult("proposal_data_1.slot != proposal_data_2.slot");
     }
 
     if (!proposerSlashing
-        .getProposalData1()
+        .getProposal1()
         .getShard()
-        .equals(proposerSlashing.getProposalData2().getShard())) {
+        .equals(proposerSlashing.getProposal2().getShard())) {
       return failedResult("proposal_data_1.shard != proposal_data_2.shard");
     }
 
     if (proposerSlashing
-        .getProposalData1()
+        .getProposal1()
         .getBlockRoot()
-        .equals(proposerSlashing.getProposalData2().getBlockRoot())) {
+        .equals(proposerSlashing.getProposal2().getBlockRoot())) {
       return failedResult(
           "proposal_data_1.block_root == proposal_data_2.block_root, roots should not be equal");
     }
@@ -64,22 +64,22 @@ public class ProposerSlashingVerifier implements OperationVerifier<ProposerSlash
 
     if (!specHelpers.bls_verify(
         proposer.getPubKey(),
-        specHelpers.hash_tree_root(proposerSlashing.getProposalData1()),
+        specHelpers.signed_root(proposerSlashing.getProposal1(), "signature"),
         proposerSlashing.getProposalSignature1(),
         specHelpers.get_domain(
             state.getForkData(),
-            specHelpers.slot_to_epoch(proposerSlashing.getProposalData1().getSlot()),
+            specHelpers.slot_to_epoch(proposerSlashing.getProposal1().getSlot()),
             PROPOSAL))) {
       return failedResult("proposal_signature_1 is invalid");
     }
 
     if (!specHelpers.bls_verify(
         proposer.getPubKey(),
-        specHelpers.hash_tree_root(proposerSlashing.getProposalData2()),
+        specHelpers.signed_root(proposerSlashing.getProposal2(), "signature"),
         proposerSlashing.getProposalSignature2(),
         specHelpers.get_domain(
             state.getForkData(),
-            specHelpers.slot_to_epoch(proposerSlashing.getProposalData2().getSlot()),
+            specHelpers.slot_to_epoch(proposerSlashing.getProposal2().getSlot()),
             PROPOSAL))) {
       return failedResult("proposal_signature_2 is invalid");
     }

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/TestUtils.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/TestUtils.java
@@ -1,16 +1,11 @@
 package org.ethereum.beacon.consensus;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
 import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.operations.deposit.DepositData;
 import org.ethereum.beacon.core.operations.deposit.DepositInput;
 import org.ethereum.beacon.core.spec.SignatureDomains;
 import org.ethereum.beacon.core.types.BLSPubkey;
 import org.ethereum.beacon.core.types.BLSSignature;
-import org.ethereum.beacon.core.types.Gwei;
 import org.ethereum.beacon.core.types.Time;
 import org.ethereum.beacon.crypto.BLS381;
 import org.ethereum.beacon.crypto.BLS381.KeyPair;
@@ -21,6 +16,11 @@ import tech.pegasys.artemis.ethereum.core.Hash32;
 import tech.pegasys.artemis.util.bytes.Bytes48;
 import tech.pegasys.artemis.util.bytes.Bytes96;
 import tech.pegasys.artemis.util.uint.UInt64;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 public class TestUtils {
   private static final Random rnd = new Random();
@@ -50,7 +50,7 @@ public class TestUtils {
           proofOfPosession,
           BLSSignature.wrap(Bytes96.ZERO)
       );
-      Hash32 msgHash = specHelpers.hash_tree_root(depositInputWithoutSignature);
+      Hash32 msgHash = specHelpers.signed_root(depositInputWithoutSignature, "proofOfPossession");
       Signature signature = BLS381
           .sign(new Impl(msgHash, SignatureDomains.DEPOSIT.toBytesBigEndian()), keyPair);
 

--- a/core/src/main/java/org/ethereum/beacon/core/BeaconBlock.java
+++ b/core/src/main/java/org/ethereum/beacon/core/BeaconBlock.java
@@ -68,11 +68,6 @@ public class BeaconBlock {
     return new BeaconBlock(slot, parentRoot, stateRoot, randaoReveal, eth1Data, signature, body);
   }
 
-  public BeaconBlock withoutSignature() {
-    return new BeaconBlock(
-        slot, parentRoot, stateRoot, randaoReveal, eth1Data, BLSSignature.ZERO, body);
-  }
-
   public SlotNumber getSlot() {
     return slot;
   }

--- a/core/src/main/java/org/ethereum/beacon/core/operations/ProposerSlashing.java
+++ b/core/src/main/java/org/ethereum/beacon/core/operations/ProposerSlashing.java
@@ -2,7 +2,8 @@ package org.ethereum.beacon.core.operations;
 
 import com.google.common.base.Objects;
 import javax.annotation.Nullable;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.core.types.Time;
@@ -13,21 +14,21 @@ import org.ethereum.beacon.ssz.annotation.SSZSerializable;
 @SSZSerializable
 public class ProposerSlashing {
   @SSZ private final ValidatorIndex proposerIndex;
-  @SSZ private final ProposalSignedData proposalData1;
+  @SSZ private final Proposal proposal1;
   @SSZ private final BLSSignature proposalSignature1;
-  @SSZ private final ProposalSignedData proposalData2;
+  @SSZ private final Proposal proposal2;
   @SSZ private final BLSSignature proposalSignature2;
 
   public ProposerSlashing(
       ValidatorIndex proposerIndex,
-      ProposalSignedData proposalData1,
+      Proposal proposal1,
       BLSSignature proposalSignature1,
-      ProposalSignedData proposalData2,
+      Proposal proposal2,
       BLSSignature proposalSignature2) {
     this.proposerIndex = proposerIndex;
-    this.proposalData1 = proposalData1;
+    this.proposal1 = proposal1;
     this.proposalSignature1 = proposalSignature1;
-    this.proposalData2 = proposalData2;
+    this.proposal2 = proposal2;
     this.proposalSignature2 = proposalSignature2;
   }
 
@@ -35,16 +36,16 @@ public class ProposerSlashing {
     return proposerIndex;
   }
 
-  public ProposalSignedData getProposalData1() {
-    return proposalData1;
+  public Proposal getProposal1() {
+    return proposal1;
   }
 
   public BLSSignature getProposalSignature1() {
     return proposalSignature1;
   }
 
-  public ProposalSignedData getProposalData2() {
-    return proposalData2;
+  public Proposal getProposal2() {
+    return proposal2;
   }
 
   public BLSSignature getProposalSignature2() {
@@ -57,9 +58,9 @@ public class ProposerSlashing {
     if (o == null || getClass() != o.getClass()) return false;
     ProposerSlashing that = (ProposerSlashing) o;
     return Objects.equal(proposerIndex, that.proposerIndex)
-        && Objects.equal(proposalData1, that.proposalData1)
+        && Objects.equal(proposal1, that.proposal1)
         && Objects.equal(proposalSignature1, that.proposalSignature1)
-        && Objects.equal(proposalData2, that.proposalData2)
+        && Objects.equal(proposal2, that.proposal2)
         && Objects.equal(proposalSignature2, that.proposalSignature2);
   }
 
@@ -71,8 +72,8 @@ public class ProposerSlashing {
   public String toString(@Nullable ChainSpec spec, @Nullable Time beaconStart) {
     return "ProposerSlashing["
         + "proposer: " + proposerIndex
-        + ", data1: " + proposalData1.toString(spec, beaconStart)
-        + ", data2: " + proposalData2.toString(spec, beaconStart)
+        + ", data1: " + proposal1.toString(spec, beaconStart)
+        + ", data2: " + proposal2.toString(spec, beaconStart)
         + ", sig1: " + proposalSignature1
         + ", sig2: " + proposalSignature2
         + "]";

--- a/core/src/main/java/org/ethereum/beacon/core/operations/slashing/Proposal.java
+++ b/core/src/main/java/org/ethereum/beacon/core/operations/slashing/Proposal.java
@@ -3,6 +3,7 @@ package org.ethereum.beacon.core.operations.slashing;
 import com.google.common.base.Objects;
 import javax.annotation.Nullable;
 import org.ethereum.beacon.core.spec.ChainSpec;
+import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.core.types.ShardNumber;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.Time;
@@ -11,7 +12,7 @@ import org.ethereum.beacon.ssz.annotation.SSZSerializable;
 import tech.pegasys.artemis.ethereum.core.Hash32;
 
 @SSZSerializable
-public class ProposalSignedData {
+public class Proposal {
 
   @SSZ
   private final SlotNumber slot;
@@ -19,11 +20,14 @@ public class ProposalSignedData {
   private final ShardNumber shard;
   @SSZ
   private final Hash32 blockRoot;
+  @SSZ
+  private final BLSSignature signature;
 
-  public ProposalSignedData(SlotNumber slot, ShardNumber shard, Hash32 blockRoot) {
+  public Proposal(SlotNumber slot, ShardNumber shard, Hash32 blockRoot, BLSSignature blsSignature) {
     this.slot = slot;
     this.shard = shard;
     this.blockRoot = blockRoot;
+    this.signature = blsSignature;
   }
 
   public SlotNumber getSlot() {
@@ -38,23 +42,28 @@ public class ProposalSignedData {
     return blockRoot;
   }
 
+  public BLSSignature getSignature() {
+    return signature;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o)
       return true;
     if (o == null || getClass() != o.getClass())
       return false;
-    ProposalSignedData that = (ProposalSignedData) o;
+    Proposal that = (Proposal) o;
     return Objects.equal(slot, that.slot)
         && Objects.equal(shard, that.shard)
         && Objects.equal(blockRoot, that.blockRoot);
   }
 
   public String toString(@Nullable ChainSpec spec, @Nullable Time beaconStart) {
-    return "ProposalSignedData["
+    return "Proposal["
         + "slot=" + slot.toString(spec, beaconStart)
         + "shard=" + shard.toString(spec)
         + "block=" + blockRoot.toStringShort()
+        + "signature=" + signature.toString()
         + "]";
   }
 }

--- a/core/src/test/java/org/ethereum/beacon/core/ModelsSerializeTest.java
+++ b/core/src/test/java/org/ethereum/beacon/core/ModelsSerializeTest.java
@@ -1,11 +1,5 @@
 package org.ethereum.beacon.core;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.ethereum.beacon.core.operations.Attestation;
 import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.operations.Exit;
@@ -14,7 +8,7 @@ import org.ethereum.beacon.core.operations.attestation.AttestationData;
 import org.ethereum.beacon.core.operations.deposit.DepositData;
 import org.ethereum.beacon.core.operations.deposit.DepositInput;
 import org.ethereum.beacon.core.operations.slashing.AttesterSlashing;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.operations.slashing.SlashableAttestation;
 import org.ethereum.beacon.core.state.BeaconStateImpl;
 import org.ethereum.beacon.core.state.CrosslinkRecord;
@@ -41,6 +35,13 @@ import tech.pegasys.artemis.util.bytes.Bytes48;
 import tech.pegasys.artemis.util.bytes.Bytes96;
 import tech.pegasys.artemis.util.bytes.BytesValue;
 import tech.pegasys.artemis.util.uint.UInt64;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class ModelsSerializeTest {
   private Serializer sszSerializer;
@@ -167,18 +168,21 @@ public class ModelsSerializeTest {
     assertEquals(expected, reconstructed);
   }
 
-  private ProposalSignedData createProposalSignedData() {
-    ProposalSignedData proposalSignedData =
-        new ProposalSignedData(
-            SlotNumber.of(12), ShardNumber.ZERO, Hashes.keccak256(BytesValue.fromHexString("aa")));
-    return proposalSignedData;
+  private Proposal createProposalSignedData() {
+    Proposal proposal =
+        new Proposal(
+            SlotNumber.of(12),
+            ShardNumber.ZERO,
+            Hashes.keccak256(BytesValue.fromHexString("aa")),
+            BLSSignature.ZERO);
+    return proposal;
   }
 
   @Test
   public void proposalSignedDataTest() {
-    ProposalSignedData expected = createProposalSignedData();
+    Proposal expected = createProposalSignedData();
     BytesValue encoded = sszSerializer.encode2(expected);
-    ProposalSignedData reconstructed = sszSerializer.decode(encoded, ProposalSignedData.class);
+    Proposal reconstructed = sszSerializer.decode(encoded, Proposal.class);
     assertEquals(expected, reconstructed);
   }
 

--- a/core/src/test/java/org/ethereum/beacon/core/SSZSerializableAnnotationTest.java
+++ b/core/src/test/java/org/ethereum/beacon/core/SSZSerializableAnnotationTest.java
@@ -18,7 +18,7 @@ import org.ethereum.beacon.core.operations.attestation.AttestationDataAndCustody
 import org.ethereum.beacon.core.operations.deposit.DepositData;
 import org.ethereum.beacon.core.operations.deposit.DepositInput;
 import org.ethereum.beacon.core.operations.slashing.AttesterSlashing;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.operations.slashing.SlashableAttestation;
 import org.ethereum.beacon.core.state.BeaconStateImpl;
 import org.ethereum.beacon.core.state.CrosslinkRecord;
@@ -125,7 +125,7 @@ public class SSZSerializableAnnotationTest {
                 DepositData.class,
                 DepositInput.class,
                 Exit.class,
-                ProposalSignedData.class,
+                Proposal.class,
                 ProposerSlashing.class,
                 CrosslinkRecord.class,
                 Eth1DataVote.class,

--- a/core/src/test/java/org/ethereum/beacon/core/util/ProposerSlashingTestUtil.java
+++ b/core/src/test/java/org/ethereum/beacon/core/util/ProposerSlashingTestUtil.java
@@ -5,7 +5,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.ethereum.beacon.core.operations.ProposerSlashing;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.core.types.ValidatorIndex;
@@ -22,12 +22,12 @@ public abstract class ProposerSlashingTestUtil {
   }
 
   public static ProposerSlashing createRandom(Random random) {
-    ProposalSignedData signedData1 =
-        new ProposalSignedData(
-            ChainSpec.GENESIS_SLOT, ChainSpec.BEACON_CHAIN_SHARD_NUMBER, Hash32.random(random));
-    ProposalSignedData signedData2 =
-        new ProposalSignedData(
-            ChainSpec.GENESIS_SLOT, ChainSpec.BEACON_CHAIN_SHARD_NUMBER, Hash32.random(random));
+    Proposal signedData1 =
+        new Proposal(
+            ChainSpec.GENESIS_SLOT, ChainSpec.BEACON_CHAIN_SHARD_NUMBER, Hash32.random(random), BLSSignature.ZERO);
+    Proposal signedData2 =
+        new Proposal(
+            ChainSpec.GENESIS_SLOT, ChainSpec.BEACON_CHAIN_SHARD_NUMBER, Hash32.random(random), BLSSignature.ZERO);
     return new ProposerSlashing(
         ValidatorIndex.ZERO,
         signedData1,

--- a/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationServiceImpl.java
+++ b/pow/validator/src/main/java/org/ethereum/beacon/pow/validator/ValidatorRegistrationServiceImpl.java
@@ -277,7 +277,7 @@ public class ValidatorRegistrationServiceImpl implements ValidatorRegistrationSe
         new DepositInput(pubKey, withdrawalCredentials, BLSSignature.ZERO);
     // Let proof_of_possession be the result of bls_sign of the hash_tree_root(deposit_input) with
     // domain=DOMAIN_DEPOSIT.
-    Hash32 hash = specHelpers.hash_tree_root(preDepositInput);
+    Hash32 hash = specHelpers.signed_root(preDepositInput, "proofOfPossession");
     BeaconState latestState = getLatestState();
     Bytes8 domain =
         specHelpers.get_domain(

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/BytesHasher.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/BytesHasher.java
@@ -1,0 +1,35 @@
+package org.ethereum.beacon.ssz;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Hasher Class -> bytes[] */
+public interface BytesHasher {
+  /**
+   * Hashes input
+   *
+   * @param input Input value
+   * @param clazz Class of value
+   * @return serialization
+   */
+  <C> byte[] hash(@Nullable C input, Class<? extends C> clazz);
+
+  /**
+   * Hashes truncated input. Prepares virtual object, which gets all fields from input till `field`
+   * (not included) and calculates hash for it
+   *
+   * @param input Input value
+   * @param clazz Class of value
+   * @param field Field in input value which and all fields after are truncated
+   * @return serialization
+   */
+  <C> byte[] hashTruncate(@Nullable C input, Class<? extends C> clazz, String field);
+
+  /**
+   * Shortcut to {@link #hash(Object, Class)}. Resolves class using input object. Not suitable for
+   * null values.
+   */
+  default <C> byte[] hash(@Nonnull C input) {
+    return hash(input, input.getClass());
+  }
+}

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/SSZCodecHasher.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/SSZCodecHasher.java
@@ -51,7 +51,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
     });
   }
 
-  public Consumer<Triplet<Object, OutputStream, SSZSerializer>> resolveEncodeFunction(
+  public Consumer<Triplet<Object, OutputStream, BytesSerializer>> resolveEncodeFunction(
       SSZSchemeBuilder.SSZScheme.SSZField field) {
     SSZCodec encoder = resolveCodec(field);
 
@@ -72,7 +72,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
         return objects -> {
           Object value = objects.getValue0();
           OutputStream res = objects.getValue1();
-          SSZSerializer sszSerializer = objects.getValue2();
+          BytesSerializer sszSerializer = objects.getValue2();
           encodeContainer(value, field, res, sszSerializer);
         };
       }
@@ -92,7 +92,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
           }
           elements = listElements;
         } else {
-          SSZSerializer sszSerializer = objects.getValue2();
+          BytesSerializer sszSerializer = objects.getValue2();
           elements = packContainerList((List<Object>) value, field, sszSerializer);
         }
         try {
@@ -117,7 +117,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
           }
           elements = arrayElements;
         } else {
-          SSZSerializer sszSerializer = objects.getValue2();
+          BytesSerializer sszSerializer = objects.getValue2();
           elements = packContainerList(Arrays.asList((Object[]) value), field, sszSerializer);
         }
         try {
@@ -136,7 +136,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
       Object value,
       SSZSchemeBuilder.SSZScheme.SSZField field,
       OutputStream result,
-      SSZSerializer sszSerializer) {
+      BytesSerializer sszSerializer) {
     byte[] data = sszSerializer.encode(value, field.type);
 
     if (!field.notAContainer) {
@@ -158,7 +158,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
   }
 
   private Bytes[] packContainerList(
-      List<Object> values, SSZSchemeBuilder.SSZScheme.SSZField field, SSZSerializer sszSerializer) {
+      List<Object> values, SSZSchemeBuilder.SSZScheme.SSZField field, BytesSerializer sszSerializer) {
     Bytes[] res = new Bytes[values.size()];
     for (int i = 0; i < values.size(); ++i) {
       byte[] data = sszSerializer.encode(values.get(i), field.type);
@@ -174,7 +174,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
     return res;
   }
 
-  public Function<Pair<BytesSSZReaderProxy, SSZSerializer>, Object> resolveDecodeFunction(
+  public Function<Pair<BytesSSZReaderProxy, BytesSerializer>, Object> resolveDecodeFunction(
       SSZSchemeBuilder.SSZScheme.SSZField field) {
     throw new SSZException("Decode is not supported for hash");
   }

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/SSZCodecResolver.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/SSZCodecResolver.java
@@ -31,7 +31,7 @@ public interface SSZCodecResolver {
    * @param field Field
    * @return encode function
    */
-  Consumer<Triplet<Object, OutputStream, SSZSerializer>> resolveEncodeFunction(
+  Consumer<Triplet<Object, OutputStream, BytesSerializer>> resolveEncodeFunction(
       SSZSchemeBuilder.SSZScheme.SSZField field);
 
   /**
@@ -40,6 +40,6 @@ public interface SSZCodecResolver {
    * @param field Field
    * @return decode function
    */
-  Function<Pair<BytesSSZReaderProxy, SSZSerializer>, Object> resolveDecodeFunction(
+  Function<Pair<BytesSSZReaderProxy, BytesSerializer>, Object> resolveDecodeFunction(
       SSZSchemeBuilder.SSZScheme.SSZField field);
 }

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/SSZHashSerializer.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/SSZHashSerializer.java
@@ -1,42 +1,55 @@
 package org.ethereum.beacon.ssz;
 
 import org.javatuples.Triplet;
+
 import javax.annotation.Nullable;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
+import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.ethereum.beacon.ssz.SSZSerializer.checkSSZSerializableAnnotation;
 
 /**
- * Extends {@link SSZSerializer} to match Tree Hash algorithm.
+ * Implements Tree Hash algorithm.
  *
  * @see <a
  *     href="https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#tree-hash">SSZ
  *     Tree Hash</a> in the spec
  */
-public class SSZHashSerializer extends SSZSerializer {
+public class SSZHashSerializer implements BytesHasher, BytesSerializer {
 
+  private static final byte[] EMPTY_PREFIX = SSZSerializer.EMPTY_PREFIX;
   private static final int HASH_LENGTH = 32;
 
-  public SSZHashSerializer(
-      SSZSchemeBuilder schemeBuilder,
-      SSZCodecResolver codecResolver,
-      SSZModelFactory sszModelFactory) {
-    super(schemeBuilder, codecResolver, sszModelFactory);
-  }
+  private SSZSchemeBuilder schemeBuilder;
+
+  private SSZCodecResolver codecResolver;
 
   /**
-   * Shortcut to {@link #encode(Object, Class)}. Resolves class using input object. Not suitable for
-   * null values.
+   * SSZ hasher with following helpers
    *
-   * @param input
+   * @param schemeBuilder SSZ model scheme building of type {@link SSZSchemeBuilder.SSZScheme}
+   * @param codecResolver Resolves field encoder/decoder {@link
+   *     org.ethereum.beacon.ssz.type.SSZCodec} function
    */
+  public SSZHashSerializer(SSZSchemeBuilder schemeBuilder, SSZCodecResolver codecResolver) {
+    this.schemeBuilder = schemeBuilder;
+    this.codecResolver = codecResolver;
+  }
+
+  /** Calculates hash of the input object */
   @Override
-  public byte[] encode(@Nullable Object input, Class clazz) {
+  public byte[] hash(@Nullable Object input, Class clazz) {
     byte[] preBakedHash;
     if (input instanceof List) {
-      preBakedHash = encodeList((List) input);
+      preBakedHash = hashList((List) input);
     } else {
-      preBakedHash = super.encode(input, clazz);
+      preBakedHash = hashImpl(input, clazz, null);
     }
     // For the final output only (ie. not intermediate outputs), if the output is less than 32
     // bytes, right-zero-pad it to 32 bytes.
@@ -51,7 +64,92 @@ public class SSZHashSerializer extends SSZSerializer {
     return res;
   }
 
-  private byte[] encodeList(List input) {
+  private byte[] hashImpl(@Nullable Object input, Class clazz, @Nullable String truncateField) {
+    checkSSZSerializableAnnotation(clazz);
+
+    // Null check
+    if (input == null) {
+      return EMPTY_PREFIX;
+    }
+
+    // Fill up map with all available method getters
+    Map<String, Method> getters = new HashMap<>();
+    try {
+      for (PropertyDescriptor pd : Introspector.getBeanInfo(clazz).getPropertyDescriptors()) {
+        getters.put(pd.getReadMethod().getName(), pd.getReadMethod());
+      }
+    } catch (IntrospectionException e) {
+      String error = String.format("Couldn't enumerate all getters in class %s", clazz.getName());
+      throw new RuntimeException(error, e);
+    }
+
+    // Encode object fields one by one
+    SSZSchemeBuilder.SSZScheme fullScheme = schemeBuilder.build(clazz);
+    SSZSchemeBuilder.SSZScheme scheme;
+    if (truncateField == null) {
+      scheme = fullScheme;
+    } else {
+      scheme = new SSZSchemeBuilder.SSZScheme();
+      boolean fieldFound = false;
+      for (SSZSchemeBuilder.SSZScheme.SSZField field : fullScheme.fields) {
+        if (field.name.equals(truncateField)) {
+          fieldFound = true;
+          break;
+        }
+        scheme.fields.add(field);
+      }
+      if (!fieldFound) {
+        throw new RuntimeException(
+            String.format("Field %s doesn't exist in object %s", truncateField, input));
+      }
+    }
+    ByteArrayOutputStream res = new ByteArrayOutputStream();
+    for (SSZSchemeBuilder.SSZScheme.SSZField field : scheme.fields) {
+      Object value;
+      Method getter = getters.get(field.getter);
+      try {
+        if (getter != null) { // We have getter
+          value = getter.invoke(input);
+        } else { // Trying to access field directly
+          value = clazz.getField(field.name).get(input);
+        }
+      } catch (Exception e) {
+        String error =
+            String.format(
+                "Failed to get value from field %s, your should "
+                    + "either have public field or public getter for it",
+                field.name);
+        throw new SSZSchemeException(error);
+      }
+
+      codecResolver.resolveEncodeFunction(field).accept(new Triplet<>(value, res, this));
+    }
+
+    return res.toByteArray();
+  }
+
+  @Override
+  public byte[] hashTruncate(@Nullable Object input, Class clazz, String field) {
+    byte[] preBakedHash;
+    if (input instanceof List) {
+      throw new RuntimeException("hashTruncate doesn't support lists");
+    } else {
+      preBakedHash = hashImpl(input, clazz, field);
+    }
+    // For the final output only (ie. not intermediate outputs), if the output is less than 32
+    // bytes, right-zero-pad it to 32 bytes.
+    byte[] res;
+    if (preBakedHash.length < HASH_LENGTH) {
+      res = new byte[HASH_LENGTH];
+      System.arraycopy(preBakedHash, 0, res, 0, preBakedHash.length);
+    } else {
+      res = preBakedHash;
+    }
+
+    return res;
+  }
+
+  private byte[] hashList(List input) {
     if (input.isEmpty()) {
       return new byte[0];
     }
@@ -68,5 +166,15 @@ public class SSZHashSerializer extends SSZSerializer {
     codecResolver.resolveEncodeFunction(field).accept(new Triplet<>(input, res, this));
 
     return res.toByteArray();
+  }
+
+  @Override
+  public <C> byte[] encode(@Nullable C input, Class<? extends C> clazz) {
+    return hash(input, clazz);
+  }
+
+  @Override
+  public <C> C decode(byte[] data, Class<? extends C> clazz) {
+    throw new RuntimeException("Decode function is not implemented for hash");
   }
 }

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/SSZSerializer.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/SSZSerializer.java
@@ -27,7 +27,7 @@ public class SSZSerializer implements BytesSerializer {
 
   private SSZSchemeBuilder schemeBuilder;
 
-  SSZCodecResolver codecResolver;
+  private SSZCodecResolver codecResolver;
 
   private SSZModelFactory sszModelFactory;
 
@@ -48,7 +48,7 @@ public class SSZSerializer implements BytesSerializer {
     this.sszModelFactory = sszModelFactory;
   }
 
-  void checkSSZSerializableAnnotation(Class clazz) {
+  static void checkSSZSerializableAnnotation(Class clazz) {
     if (!clazz.isAnnotationPresent(SSZSerializable.class)) {
       String error =
           String.format(

--- a/start/cli/src/main/java/org/ethereum/beacon/util/EmulateUtils.java
+++ b/start/cli/src/main/java/org/ethereum/beacon/util/EmulateUtils.java
@@ -50,7 +50,7 @@ public class EmulateUtils {
               BLSPubkey.wrap(Bytes48.leftPad(keyPair.getPublic().getEncodedBytes())),
               proofOfPosession,
               BLSSignature.wrap(Bytes96.ZERO));
-      Hash32 msgHash = specHelpers.hash_tree_root(depositInputWithoutSignature);
+      Hash32 msgHash = specHelpers.signed_root(depositInputWithoutSignature, "proofOfPossession");
       BLS381.Signature signature =
           BLS381.sign(
               new MessageParameters.Impl(msgHash, SignatureDomains.DEPOSIT.toBytesBigEndian()),

--- a/validator/src/main/java/org/ethereum/beacon/validator/BeaconChainProposer.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/BeaconChainProposer.java
@@ -2,7 +2,7 @@ package org.ethereum.beacon.validator;
 
 import org.ethereum.beacon.chain.observer.ObservableBeaconState;
 import org.ethereum.beacon.core.BeaconBlock;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.validator.crypto.MessageSigner;
 
@@ -19,7 +19,7 @@ public interface BeaconChainProposer {
    * <p>Created block should be ready to be imported in the chain and propagated to the network.
    *
    * @param observableState a state on top of which new block is created.
-   * @param signer an instance that signs off on {@link ProposalSignedData}.
+   * @param signer an instance that signs off on {@link Proposal}.
    * @return created block.
    */
   BeaconBlock propose(ObservableBeaconState observableState, MessageSigner<BLSSignature> signer);

--- a/validator/src/main/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerImpl.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerImpl.java
@@ -21,7 +21,7 @@ import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.operations.Exit;
 import org.ethereum.beacon.core.operations.ProposerSlashing;
 import org.ethereum.beacon.core.operations.slashing.AttesterSlashing;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.state.Eth1Data;
 import org.ethereum.beacon.core.state.Eth1DataVote;
@@ -115,21 +115,22 @@ public class BeaconChainProposerImpl implements BeaconChainProposer {
   }
 
   /**
-   * Creates a {@link ProposalSignedData} instance and signs off on it.
+   * Creates a {@link Proposal} instance and signs off on it.
    *
    * @param state state at the slot of created block.
-   * @param blockWithoutSignature created block with zero {@link BeaconBlock#signature} field.
+   * @param block block
    * @param signer message signer.
    * @return signature of proposal signed data.
    */
   private BLSSignature getProposalSignature(
-      BeaconState state, BeaconBlock blockWithoutSignature, MessageSigner<BLSSignature> signer) {
-    ProposalSignedData proposal =
-        new ProposalSignedData(
+      BeaconState state, BeaconBlock block, MessageSigner<BLSSignature> signer) {
+    Proposal proposal =
+        new Proposal(
             state.getSlot(),
             chainSpec.getBeaconChainShardNumber(),
-            specHelpers.hash_tree_root(blockWithoutSignature));
-    Hash32 proposalRoot = specHelpers.hash_tree_root(proposal);
+            specHelpers.signed_root(block, "signature"),
+            block.getSignature());
+    Hash32 proposalRoot = specHelpers.signed_root(proposal, "signature");
     Bytes8 domain = specHelpers.get_domain(state.getForkData(),
         specHelpers.get_current_epoch(state), PROPOSAL);
     return signer.sign(proposalRoot, domain);

--- a/validator/src/test/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerTest.java
+++ b/validator/src/test/java/org/ethereum/beacon/validator/proposer/BeaconChainProposerTest.java
@@ -24,7 +24,7 @@ import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.operations.Exit;
 import org.ethereum.beacon.core.operations.ProposerSlashing;
 import org.ethereum.beacon.core.operations.slashing.AttesterSlashing;
-import org.ethereum.beacon.core.operations.slashing.ProposalSignedData;
+import org.ethereum.beacon.core.operations.slashing.Proposal;
 import org.ethereum.beacon.core.spec.ChainSpec;
 import org.ethereum.beacon.core.spec.SignatureDomains;
 import org.ethereum.beacon.core.state.Eth1Data;
@@ -243,14 +243,15 @@ public class BeaconChainProposerTest {
       BeaconBlock block,
       MessageSigner<BLSSignature> signer) {
 
-    ProposalSignedData signedData =
-        new ProposalSignedData(
+    Proposal signedData =
+        new Proposal(
             initialState.getSlot(),
             specHelpers.getChainSpec().getBeaconChainShardNumber(),
-            specHelpers.hash_tree_root(block.withoutSignature()));
+            specHelpers.signed_root(block, "signature"),
+            block.getSignature());
     BLSSignature expectedSignature =
         signer.sign(
-            specHelpers.hash_tree_root(signedData),
+            specHelpers.signed_root(signedData,"signature"),
             specHelpers.get_domain(
                 initialState.getForkData(),
                 specHelpers.get_current_epoch(initialState),


### PR DESCRIPTION
Guys, please, take a look.
Everything is done according to v0.4 spec https://github.com/ethereum/eth2.0-specs/releases/tag/0.4.0
Resolves #87 
SSZHasher moves away from serializer more and more, so no more extend. We'd better copy-paste some parts of code than trying to still reuse it.