### PR TITLE
Ssz updates

### DIFF
--- a/consensus/src/main/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasher.java
+++ b/consensus/src/main/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasher.java
@@ -19,26 +19,20 @@ import java.util.function.Function;
 public class SSZObjectHasher implements ObjectHasher<Hash32> {
 
   private final SSZHashSerializer sszHashSerializer;
-  private final Function<BytesValue, Hash32> hashFunction;
 
-  SSZObjectHasher(SSZHashSerializer sszHashSerializer, Function<BytesValue, Hash32> hashFunction) {
+  SSZObjectHasher(SSZHashSerializer sszHashSerializer) {
     this.sszHashSerializer = sszHashSerializer;
-    this.hashFunction = hashFunction;
   }
 
   public static SSZObjectHasher create(Function<BytesValue, Hash32> hashFunction) {
     SSZHashSerializer sszHashSerializer =
         SSZHashSerializers.createWithBeaconChainTypes(hashFunction, true);
-    return new SSZObjectHasher(sszHashSerializer, hashFunction);
+    return new SSZObjectHasher(sszHashSerializer);
   }
 
   @Override
   public Hash32 getHash(Object input) {
-    if (input instanceof List) {
-      return Hash32.wrap(Bytes32.wrap(sszHashSerializer.hash(input)));
-    } else {
-      return hashFunction.apply(BytesValue.wrap(sszHashSerializer.hash(input)));
-    }
+    return Hash32.wrap(Bytes32.wrap(sszHashSerializer.hash(input)));
   }
 
   @Override
@@ -46,8 +40,7 @@ public class SSZObjectHasher implements ObjectHasher<Hash32> {
     if (input instanceof List) {
       throw new RuntimeException("Lists are not supported in truncated hash");
     } else {
-      return hashFunction.apply(
-          BytesValue.wrap(sszHashSerializer.hashTruncate(input, input.getClass(), field)));
+      return Hash32.wrap(Bytes32.wrap(sszHashSerializer.hashTruncate(input, input.getClass(), field)));
     }
   }
 }

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
@@ -108,7 +108,7 @@ public class SpecHelpersTest {
   public void testHashTreeRoot1() {
     SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     Hash32 expected =
-        Hash32.fromHexString("0x175dfc7ad9dd6f35ef93ba1bcb94fd573ca9ce7d6e4423de3d5e9ca9dca593c8");
+        Hash32.fromHexString("0xc7894df2bf3250e97d565b3549c16d828dc8105cfe5b7f67bf4d950be819bfbd");
     Hash32 actual = specHelpers.hash_tree_root(createDepositInput());
     assertEquals(expected, actual);
   }

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
@@ -108,7 +108,7 @@ public class SpecHelpersTest {
   public void testHashTreeRoot1() {
     SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     Hash32 expected =
-        Hash32.fromHexString("0xc7894df2bf3250e97d565b3549c16d828dc8105cfe5b7f67bf4d950be819bfbd");
+        Hash32.fromHexString("0x1a2017aea008e5bb8b3eb79d031f14347018353f1c58fc3a54e9fc7af7ab2fe1");
     Hash32 actual = specHelpers.hash_tree_root(createDepositInput());
     assertEquals(expected, actual);
   }

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/SpecHelpersTest.java
@@ -108,7 +108,7 @@ public class SpecHelpersTest {
   public void testHashTreeRoot1() {
     SpecHelpers specHelpers = SpecHelpers.createWithSSZHasher(ChainSpec.DEFAULT, () -> 0L);
     Hash32 expected =
-        Hash32.fromHexString("0x8fc89d0f1f435b07543b15fdf687e7fce4a754ecd9e5afbf8f0e83928a7f798f");
+        Hash32.fromHexString("0x175dfc7ad9dd6f35ef93ba1bcb94fd573ca9ce7d6e4423de3d5e9ca9dca593c8");
     Hash32 actual = specHelpers.hash_tree_root(createDepositInput());
     assertEquals(expected, actual);
   }

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasherTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasherTest.java
@@ -36,7 +36,7 @@ public class SSZObjectHasherTest {
   public void setup() {
     SSZHashSerializer sszHashSerializer =
         SSZHashSerializers.createWithBeaconChainTypes(Hashes::keccak256, false);
-    sszHasher = new SSZObjectHasher(sszHashSerializer, Hashes::keccak256);
+    sszHasher = new SSZObjectHasher(sszHashSerializer);
   }
 
   @Test
@@ -46,7 +46,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(bitfield);
     assertEquals(
         BytesValue.fromHexString(
-            "0x1487e072053dbcdc89f662bd1ddf36a2f22c3d0594c511d349dfa18e595d6d59"),
+            "0x71d6fb668707a083955a758669047e129cd7f73da7f854b60f8a809dad13e640"),
         hash);
   }
 
@@ -55,7 +55,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(DEFAULT_SIG);
     assertEquals(
         BytesValue.fromHexString(
-            "0x479653058b37be6734f8f2b5ab589be2065a4decc77cfc2ad03f883ce0c9e609"),
+            "0xdf395bd0ff83202099e844b8fd46da57d7c9b0f0af7fae875ad562877b318245"),
         hash);
   }
 
@@ -75,7 +75,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(attestationRecord);
     assertEquals(
         BytesValue.fromHexString(
-            "0x93a79f0374c8cac12d3234f7aaeee20cd5a9902bfba7dd85a21d1cceb836921e"),
+            "0xf9c649a6265388db3a012efadd34c5f426371e90450bbf83ee4020476912b3bf"),
         hash);
   }
 
@@ -96,14 +96,14 @@ public class SSZObjectHasherTest {
     BytesValue hash1 = sszHasher.getHashTruncate(attestationRecord, "justifiedBlockHash");
     assertEquals(
         BytesValue.fromHexString(
-            "0xac0c6c3e2f2d6f5af8ee3d41729018acf3aa5d8f36ea1241706c213b4cb88fc0"),
+            "0x1f1c7368d948a8e741f8ce82a2493dbf192080f38926829e47be6d1d042117eb"),
         hash1);
 
     // Sig only removed
     BytesValue hash2 = sszHasher.getHashTruncate(attestationRecord, "aggregateSig");
     assertEquals(
         BytesValue.fromHexString(
-            "0x1d54a52a350790809fb6fd16968671390f074504fbf771e4dae8c5753e07e43d"),
+            "0x0a6a337dda9092627f55f964c925da72dbc74b028f0c7b1aa6ea7305fc82b050"),
         hash2);
 
     boolean fired = false;
@@ -143,7 +143,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(attestationRecord);
     assertEquals(
         BytesValue.fromHexString(
-            "0x93a79f0374c8cac12d3234f7aaeee20cd5a9902bfba7dd85a21d1cceb836921e"),
+            "0xf9c649a6265388db3a012efadd34c5f426371e90450bbf83ee4020476912b3bf"),
         hash);
   }
 
@@ -159,7 +159,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(someObject);
     assertEquals(
         BytesValue.fromHexString(
-            "0xda54f4e7a1c2a874d9589bd283278d61433f4c21de313291efba440874d07bc3"),
+            "0xe28e68f5df2f8a5b8740d2f8d93fcc6733577e629963962db2c39f9794368b30"),
         hash);
   }
 
@@ -172,11 +172,11 @@ public class SSZObjectHasherTest {
     BytesValue hash2 = sszHasher.getHash(anotherObject2);
     assertEquals(
         BytesValue.fromHexString(
-            "0x48078cfed56339ea54962e72c37c7f588fc4f8e5bc173827ba75cb10a63a96a5"),
+            "0x8e4ddd4f8d4d3c485c82deeff4f187d60a0f3bce8a3ac0efd2a93c914a4edbd9"),
         hash1);
     assertEquals(
         BytesValue.fromHexString(
-            "0x340dd630ad21bf010b4e676dbfa9ba9a02175262d1fa356232cfde6cb5b47ef2"),
+            "0xa42fa748506bbdec60a9ccc23a74d51743e91f7d4587816bd1ffbb501bb3779c"),
         hash2);
   }
 
@@ -190,7 +190,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(anotherObjects);
     assertEquals(
         BytesValue.fromHexString(
-            "0xac239c6a7397cc176933c6b1a4d75df567c2603e49f53ea61878b1e484b62fbe"),
+            "0x5700f35a92bf27fba1543e39a11d9a077321d7b67710a7cc8bafaf81474768e3"),
         hash);
   }
 

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasherTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasherTest.java
@@ -46,7 +46,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(bitfield);
     assertEquals(
         BytesValue.fromHexString(
-            "A0B1BE2F50398CA7FE11EA48E5AFE9F89F758EC815E5C12BE21315AF6D34FA1D"),
+            "0x1487e072053dbcdc89f662bd1ddf36a2f22c3d0594c511d349dfa18e595d6d59"),
         hash);
   }
 
@@ -55,7 +55,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(DEFAULT_SIG);
     assertEquals(
         BytesValue.fromHexString(
-            "D75724A07F4EFB3B456408DD6C36C70A6DF189FAE6A09F7AD0C848F0D3341290"),
+            "0x479653058b37be6734f8f2b5ab589be2065a4decc77cfc2ad03f883ce0c9e609"),
         hash);
   }
 
@@ -75,7 +75,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(attestationRecord);
     assertEquals(
         BytesValue.fromHexString(
-            "740620beb3f42033473a7adf01b5f115ec0a72bf8c97eb36f732a6158ff8775d"),
+            "0x93a79f0374c8cac12d3234f7aaeee20cd5a9902bfba7dd85a21d1cceb836921e"),
         hash);
   }
 
@@ -96,14 +96,14 @@ public class SSZObjectHasherTest {
     BytesValue hash1 = sszHasher.getHashTruncate(attestationRecord, "justifiedBlockHash");
     assertEquals(
         BytesValue.fromHexString(
-            "0x8d5fc215a3e8c2a67c44e8c43711ce1396315366f013892cce63ad88b8e8eb9e"),
+            "0xac0c6c3e2f2d6f5af8ee3d41729018acf3aa5d8f36ea1241706c213b4cb88fc0"),
         hash1);
 
     // Sig only removed
     BytesValue hash2 = sszHasher.getHashTruncate(attestationRecord, "aggregateSig");
     assertEquals(
         BytesValue.fromHexString(
-            "0x5df5425a3581f24ec3f8508c44820d2c70c89299cf217a3a5d8e126e51b6e4ed"),
+            "0x1d54a52a350790809fb6fd16968671390f074504fbf771e4dae8c5753e07e43d"),
         hash2);
 
     boolean fired = false;
@@ -143,7 +143,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(attestationRecord);
     assertEquals(
         BytesValue.fromHexString(
-            "740620beb3f42033473a7adf01b5f115ec0a72bf8c97eb36f732a6158ff8775d"),
+            "0x93a79f0374c8cac12d3234f7aaeee20cd5a9902bfba7dd85a21d1cceb836921e"),
         hash);
   }
 
@@ -159,7 +159,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(someObject);
     assertEquals(
         BytesValue.fromHexString(
-            "BD4AB28F883B78BF4C5B3652AFCF272EAD9026C3361821A0420777A9B3C20425"),
+            "0xda54f4e7a1c2a874d9589bd283278d61433f4c21de313291efba440874d07bc3"),
         hash);
   }
 
@@ -172,11 +172,11 @@ public class SSZObjectHasherTest {
     BytesValue hash2 = sszHasher.getHash(anotherObject2);
     assertEquals(
         BytesValue.fromHexString(
-            "FB5BAAECAB62C516763CEA2DFBA17FBBC24907E4E3B0BE426BDE71BE89AF495F"),
+            "0x48078cfed56339ea54962e72c37c7f588fc4f8e5bc173827ba75cb10a63a96a5"),
         hash1);
     assertEquals(
         BytesValue.fromHexString(
-            "B7047395B0D5A9C70336FDE7E40DE2BB369FE67C8E762A35641E209B7338FDD9"),
+            "0x340dd630ad21bf010b4e676dbfa9ba9a02175262d1fa356232cfde6cb5b47ef2"),
         hash2);
   }
 
@@ -190,7 +190,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(anotherObjects);
     assertEquals(
         BytesValue.fromHexString(
-            "a9bb69cad9fb0d9a9963bf9a32f09b9c306bed6f6c95fff3e5d625fd9370646e"),
+            "0xac239c6a7397cc176933c6b1a4d75df567c2603e49f53ea61878b1e484b62fbe"),
         hash);
   }
 

--- a/consensus/src/test/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasherTest.java
+++ b/consensus/src/test/java/org/ethereum/beacon/consensus/hasher/SSZObjectHasherTest.java
@@ -46,7 +46,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(bitfield);
     assertEquals(
         BytesValue.fromHexString(
-            "0x71d6fb668707a083955a758669047e129cd7f73da7f854b60f8a809dad13e640"),
+            "0x02000000abcd0000000000000000000000000000000000000000000000000000"),
         hash);
   }
 
@@ -55,7 +55,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(DEFAULT_SIG);
     assertEquals(
         BytesValue.fromHexString(
-            "0xdf395bd0ff83202099e844b8fd46da57d7c9b0f0af7fae875ad562877b318245"),
+            "0x3d15cc04a0a366f8e0bc034db6df008f9eaf30d7bd0b1b40c4bd7bd141bd42f7"),
         hash);
   }
 
@@ -75,7 +75,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(attestationRecord);
     assertEquals(
         BytesValue.fromHexString(
-            "0xf9c649a6265388db3a012efadd34c5f426371e90450bbf83ee4020476912b3bf"),
+            "0xbfde5860f2d9e9d7e8b2a0d5d3630a09b1330197d09a359470601bae5b3839ae"),
         hash);
   }
 
@@ -96,14 +96,14 @@ public class SSZObjectHasherTest {
     BytesValue hash1 = sszHasher.getHashTruncate(attestationRecord, "justifiedBlockHash");
     assertEquals(
         BytesValue.fromHexString(
-            "0x1f1c7368d948a8e741f8ce82a2493dbf192080f38926829e47be6d1d042117eb"),
+            "0x945b6a8eac7bd3611f6fb452fd7f63d77ce3672752df45443beb0e0169bf33cb"),
         hash1);
 
     // Sig only removed
     BytesValue hash2 = sszHasher.getHashTruncate(attestationRecord, "aggregateSig");
     assertEquals(
         BytesValue.fromHexString(
-            "0x0a6a337dda9092627f55f964c925da72dbc74b028f0c7b1aa6ea7305fc82b050"),
+            "0xae3f28da5903192bff0472fc12baf3acb8c2554606c2449f833d2079188eb871"),
         hash2);
 
     boolean fired = false;
@@ -143,7 +143,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(attestationRecord);
     assertEquals(
         BytesValue.fromHexString(
-            "0xf9c649a6265388db3a012efadd34c5f426371e90450bbf83ee4020476912b3bf"),
+            "0xbfde5860f2d9e9d7e8b2a0d5d3630a09b1330197d09a359470601bae5b3839ae"),
         hash);
   }
 
@@ -159,7 +159,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(someObject);
     assertEquals(
         BytesValue.fromHexString(
-            "0xe28e68f5df2f8a5b8740d2f8d93fcc6733577e629963962db2c39f9794368b30"),
+            "0xb1a18810e9b465f89b07c45716aef51cb243892a9ca24b37a4c322752fb905d6"),
         hash);
   }
 
@@ -172,11 +172,11 @@ public class SSZObjectHasherTest {
     BytesValue hash2 = sszHasher.getHash(anotherObject2);
     assertEquals(
         BytesValue.fromHexString(
-            "0x8e4ddd4f8d4d3c485c82deeff4f187d60a0f3bce8a3ac0efd2a93c914a4edbd9"),
+            "0x0100000000000000000000000000000000000000000000000000000000000000"),
         hash1);
     assertEquals(
         BytesValue.fromHexString(
-            "0xa42fa748506bbdec60a9ccc23a74d51743e91f7d4587816bd1ffbb501bb3779c"),
+            "0x0200000000000000000000000000000000000000000000000000000000000000"),
         hash2);
   }
 
@@ -190,7 +190,7 @@ public class SSZObjectHasherTest {
     BytesValue hash = sszHasher.getHash(anotherObjects);
     assertEquals(
         BytesValue.fromHexString(
-            "0x5700f35a92bf27fba1543e39a11d9a077321d7b67710a7cc8bafaf81474768e3"),
+            "0x6d3a1eb14c6b37eb4645044d0c1bf38284b408eab24e89238a8058f3b921e5d9"),
         hash);
   }
 

--- a/core/src/main/java/org/ethereum/beacon/core/operations/deposit/DepositInput.java
+++ b/core/src/main/java/org/ethereum/beacon/core/operations/deposit/DepositInput.java
@@ -7,8 +7,6 @@ import org.ethereum.beacon.core.types.BLSSignature;
 import org.ethereum.beacon.ssz.annotation.SSZ;
 import org.ethereum.beacon.ssz.annotation.SSZSerializable;
 import tech.pegasys.artemis.ethereum.core.Hash32;
-import tech.pegasys.artemis.util.bytes.Bytes48;
-import tech.pegasys.artemis.util.bytes.Bytes96;
 
 /**
  * An input parameters of deposit contract.
@@ -30,9 +28,7 @@ public class DepositInput {
   @SSZ private final BLSSignature proofOfPossession;
 
   public DepositInput(
-      BLSPubkey pubKey,
-      Hash32 withdrawalCredentials,
-      BLSSignature proofOfPossession) {
+      BLSPubkey pubKey, Hash32 withdrawalCredentials, BLSSignature proofOfPossession) {
     this.pubKey = pubKey;
     this.withdrawalCredentials = withdrawalCredentials;
     this.proofOfPossession = proofOfPossession;

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/SSZCodecHasher.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/SSZCodecHasher.java
@@ -31,7 +31,7 @@ import tech.pegasys.artemis.util.bytes.BytesValue;
  */
 public class SSZCodecHasher implements SSZCodecResolver {
 
-  private static final int SSZ_CHUNK_SIZE = 32;
+  static final int SSZ_CHUNK_SIZE = 32;
 
   private static final Bytes EMPTY_CHUNK = Bytes.of(new byte[SSZ_CHUNK_SIZE]);
 
@@ -63,7 +63,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
           ByteArrayOutputStream tmp = new ByteArrayOutputStream();
           encoder.encode(value, field, tmp);
           try {
-            res.write(hash_tree_root_element(Bytes.wrap(tmp.toByteArray())).toArrayUnsafe());
+            res.write(hash_tree_root_internal(Bytes.wrap(tmp.toByteArray())).toArrayUnsafe());
           } catch (IOException e) {
             throw new SSZException("Failed to write data length to stream", e);
           }
@@ -235,7 +235,7 @@ public class SSZCodecHasher implements SSZCodecResolver {
    * @param lst
    * @return
    */
-  private Bytes merkle_hash(Bytes[] lst) {
+  Bytes merkle_hash(Bytes[] lst) {
     // Store length of list (to compensate for non-bijectiveness of padding)
     Bytes dataLen = SSZ.encodeInt32(lst.length);
 
@@ -294,19 +294,24 @@ public class SSZCodecHasher implements SSZCodecResolver {
     return 0;
   }
 
-  private Bytes zpad(Bytes input, int length) {
+  Bytes zpad(Bytes input, int length) {
+    try {
     return Bytes.concatenate(input, Bytes.wrap(new byte[length - input.size()]));
+    } catch (Exception ex) {
+      System.out.println("");
+      return null;
+    }
   }
 
   private Bytes hash_tree_root_list(Bytes[] lst) {
     Bytes[] res = new Bytes[lst.length];
     for (int i = 0; i < lst.length; ++i) {
-      res[i] = hash_tree_root_element(lst[i]);
+      res[i] = hash_tree_root_internal(lst[i]);
     }
     return merkle_hash(res);
   }
 
-  private Bytes hash_tree_root_element(Bytes el) {
+  Bytes hash_tree_root_internal(Bytes el) {
     if (el.size() <= SSZ_CHUNK_SIZE) {
       return el;
     } else {

--- a/ssz/src/main/java/org/ethereum/beacon/ssz/type/BytesPrimitive.java
+++ b/ssz/src/main/java/org/ethereum/beacon/ssz/type/BytesPrimitive.java
@@ -6,6 +6,7 @@ import net.consensys.cava.ssz.SSZ;
 import net.consensys.cava.ssz.SSZException;
 import org.ethereum.beacon.ssz.SSZSchemeBuilder;
 import org.ethereum.beacon.ssz.SSZSchemeException;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashSet;
@@ -85,7 +86,11 @@ public class BytesPrimitive implements SSZCodec {
         }
       case BYTES:
         {
-          res = SSZ.encodeByteArray(data);
+          if (byteType.size == null) {
+            res = SSZ.encodeByteArray(data);
+          } else {
+            res = SSZ.encodeHash(Bytes.wrap(data)); // w/o length prefix
+          }
           break;
         }
       default:
@@ -122,7 +127,11 @@ public class BytesPrimitive implements SSZCodec {
           }
         case ADDRESS:
           {
-            result.write(SSZ.encodeAddressList(data).toArrayUnsafe());
+            if (bytesType.size == null) {
+              result.write(SSZ.encodeAddressList(data).toArrayUnsafe());
+            } else {
+              result.write(SSZ.encodeHashList(data).toArrayUnsafe());
+            }
             break;
           }
         default:
@@ -144,7 +153,7 @@ public class BytesPrimitive implements SSZCodec {
         {
           return (bytesType.size == null)
               ? reader.readBytes().toArrayUnsafe()
-              : reader.readBytes(bytesType.size).toArrayUnsafe();
+              : reader.readHash(bytesType.size).toArrayUnsafe();
         }
       case HASH:
         {
@@ -167,7 +176,11 @@ public class BytesPrimitive implements SSZCodec {
     switch (bytesType.type) {
       case BYTES:
         {
-          return (List<Object>) (List<?>) reader.readByteArrayList();
+          if (bytesType.size == null) {
+            return (List<Object>) (List<?>) reader.readByteArrayList();
+          } else {
+            return (List<Object>) (List<?>) reader.readHashList(bytesType.size);
+          }
         }
       case HASH:
         {

--- a/ssz/src/test/java/org/ethereum/beacon/ssz/SSZSerializerTest.java
+++ b/ssz/src/test/java/org/ethereum/beacon/ssz/SSZSerializerTest.java
@@ -207,7 +207,7 @@ public class SSZSerializerTest {
   public void shouldWorkLikeCavaWithObjects() {
     Bytes bytes =
         fromHexString(
-            "0x00000003426F62040000000000000000000000000000000000000000000000000000011F71B70768");
+            "0x03000000426F62046807B7711F010000000000000000000000000000000000000000000000000000");
     SomeObject readObject =
         SSZ.decode(bytes, r -> new SomeObject(r.readString(), r.readInt8(), r.readBigInteger(256)));
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,6 +1,5 @@
 ext {
-  // After that version snapshots are compiled with new JDK w/o full backward compatibility
-  cavaVersion = '0.6.0-5618C0-snapshot'
+  cavaVersion = '1.0.0-876579-snapshot'
   jacksonVersion = '2.9.8'
   log4j2Version = '2.11.2'
 }


### PR DESCRIPTION
Fixes all ssz debts:
1) resolves #19
2) renames `hash_tree_root` to `hash_tree_root_internal`
[ethereum/eth2.0-specs#543](https://github.com/ethereum/eth2.0-specs/pull/543)
3) uses `merkle_hash` instead of `hash` for containers
[ethereum/eth2.0-specs#595](https://github.com/ethereum/eth2.0-specs/pull/595)
it had error in the spec but spec is going to be rewritten with fix of this error, so it's not up to v0.4 version spec, because it has my own fix and it's not up to rewritten spec, because it's not final. Anyway 0.4 is not correct in ssz
4) Tree hash `bytes[]` as `List(Bytes1)` and skip length prefix for fixed byte arrays
[ethereum/eth2.0-specs#596](https://github.com/ethereum/eth2.0-specs/pull/596)