### PR TITLE
Improve peers configuration

### DIFF
--- a/start/common/src/test/resources/log4j2-test.xml
+++ b/start/common/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
     <Routing name="validatorFile">
       <Routes pattern="$${ctx:validatorIndex:-X}">
         <Route>
-          <File name="dummy" fileName="logs/validator-${ctx:validatorIndex:-X}.log" append="false">
+          <File name="dummy" fileName="logs/peer-${ctx:validatorIndex:-X}.log" append="false">
             <PatternLayout>
               <Pattern>%d{HH:mm:ss.SSS} [%X{validatorTime}] %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>

--- a/start/config/src/main/java/org/ethereum/beacon/emulator/config/simulator/PeersConfig.java
+++ b/start/config/src/main/java/org/ethereum/beacon/emulator/config/simulator/PeersConfig.java
@@ -13,6 +13,29 @@ public class PeersConfig {
 
   private String blsPrivateKey = null;
 
+  public PeersConfig(
+      int count,
+      boolean validator,
+      long systemTimeShift,
+      long wireInboundDelay,
+      long wireOutboundDelay,
+      String blsPrivateKey) {
+    this.count = count;
+    this.validator = validator;
+    this.systemTimeShift = systemTimeShift;
+    this.wireInboundDelay = wireInboundDelay;
+    this.wireOutboundDelay = wireOutboundDelay;
+    this.blsPrivateKey = blsPrivateKey;
+  }
+
+  public PeersConfig() {
+  }
+
+  public PeersConfig(int count, boolean validator) {
+    this.count = count;
+    this.validator = validator;
+  }
+
   public int getCount() {
     return count;
   }

--- a/start/simulator/src/main/resources/log4j2.xml
+++ b/start/simulator/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
     <Routing name="validatorFile">
       <Routes pattern="$${ctx:validatorIndex:-X}">
         <Route>
-          <File name="dummy" fileName="logs/validator-${ctx:validatorIndex:-X}.log" append="false">
+          <File name="dummy" fileName="logs/peer-${ctx:validatorIndex:-X}.log" append="false">
             <PatternLayout>
               <Pattern>%d{HH:mm:ss.SSS} [%X{validatorTime}] %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>


### PR DESCRIPTION
### What's done
- observers and validators are now decoupled in code and in logs
- observers defined in simulation plan are now created and added to peers participating in simulation
- fixed latest state output, there were irrelevant _not latest_ states added by a system observer peer
- log files naming is improved: 
```
validators:
peer-V0.log
peer-V1.log

observers:
peer-O0.log
peer-O1.log
```