### PR TITLE
BLS key pair generator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "test/src/test/resources/eth2.0-tests"]
 	path = test/src/test/resources/eth2.0-tests
 	url = https://github.com/ethereum/eth2.0-tests.git
+[submodule "crypto/src/main/resources/bls-key-pairs"]
+	path = crypto/src/main/resources/bls-key-pairs
+	url = https://github.com/harmony-dev/bls-key-pairs

--- a/crypto/src/main/java/org/ethereum/beacon/crypto/BLS381.java
+++ b/crypto/src/main/java/org/ethereum/beacon/crypto/BLS381.java
@@ -376,6 +376,10 @@ public class BLS381 {
       return new PublicKey(encoded);
     }
 
+    public static PublicKey createWithoutValidation(Bytes48 encoded) {
+      return new PublicKey(encoded);
+    }
+
     /**
      * Aggregates a list of public keys to a single one.
      *

--- a/crypto/src/main/java/org/ethereum/beacon/crypto/BLS381.java
+++ b/crypto/src/main/java/org/ethereum/beacon/crypto/BLS381.java
@@ -449,6 +449,10 @@ public class BLS381 {
       return new KeyPair(PublicKey.create(privateKey), privateKey);
     }
 
+    public String asString() {
+      return String.format("%s:%s", privateKey.encoded, publicKey.encoded);
+    }
+
     /**
      * Generates a new key pair using Bouncy Castle key generator.
      *

--- a/crypto/src/main/java/org/ethereum/beacon/crypto/BLS381.java
+++ b/crypto/src/main/java/org/ethereum/beacon/crypto/BLS381.java
@@ -376,6 +376,15 @@ public class BLS381 {
       return new PublicKey(encoded);
     }
 
+    /**
+     * Instantiates key from encoded <code>G<sub>1</sub></code> point.
+     *
+     * <p><strong>Note:</strong> opposite to {@link #create(Bytes48)} does not run format
+     * validation.
+     *
+     * @param encoded an encoded point.
+     * @return an instance of public key.
+     */
     public static PublicKey createWithoutValidation(Bytes48 encoded) {
       return new PublicKey(encoded);
     }

--- a/crypto/src/main/java/org/ethereum/beacon/crypto/util/BlsKeyPairGenerator.java
+++ b/crypto/src/main/java/org/ethereum/beacon/crypto/util/BlsKeyPairGenerator.java
@@ -1,0 +1,44 @@
+package org.ethereum.beacon.crypto.util;
+
+import java.math.BigInteger;
+import java.util.Random;
+import org.bouncycastle.util.BigIntegers;
+import org.ethereum.beacon.crypto.BLS381.KeyPair;
+import org.ethereum.beacon.crypto.BLS381.PrivateKey;
+import org.ethereum.beacon.crypto.bls.bc.BCParameters;
+import tech.pegasys.artemis.util.bytes.Bytes32;
+
+/**
+ * Given a seed generates a sequence of {@link KeyPair} instances.
+ *
+ * <p><strong>Note:</strong> the implementation is not secure as it just uses {@link Random}.
+ */
+public class BlsKeyPairGenerator {
+  private static final BigInteger MIN = BigInteger.ONE;
+  private static final BigInteger MAX = BCParameters.ORDER.subtract(BigInteger.ONE);
+
+  private Random random;
+
+  private BlsKeyPairGenerator(Random random) {
+    this.random = random;
+  }
+
+  public static BlsKeyPairGenerator create(long seed) {
+    return new BlsKeyPairGenerator(new Random(seed));
+  }
+
+  public static BlsKeyPairGenerator createWithoutSeed() {
+    return new BlsKeyPairGenerator(new Random());
+  }
+
+  public KeyPair next() {
+    BigInteger value = BigInteger.ZERO;
+    while (value.compareTo(MIN) < 0 || value.compareTo(MAX) > 0) {
+      byte[] bytes = new byte[Bytes32.SIZE];
+      random.nextBytes(bytes);
+      value = BigIntegers.fromUnsignedByteArray(bytes);
+    }
+    PrivateKey privateKey = PrivateKey.create(value);
+    return KeyPair.create(privateKey);
+  }
+}

--- a/crypto/src/main/java/org/ethereum/beacon/crypto/util/BlsKeyPairReader.java
+++ b/crypto/src/main/java/org/ethereum/beacon/crypto/util/BlsKeyPairReader.java
@@ -1,0 +1,81 @@
+package org.ethereum.beacon.crypto.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.zip.GZIPInputStream;
+import org.ethereum.beacon.crypto.BLS381.KeyPair;
+import org.ethereum.beacon.crypto.BLS381.PrivateKey;
+import org.ethereum.beacon.crypto.BLS381.PublicKey;
+import tech.pegasys.artemis.util.bytes.Bytes32;
+import tech.pegasys.artemis.util.bytes.Bytes48;
+
+/**
+ * Given a file or resource reads BLS {@link KeyPair} instances from it.
+ *
+ * <p>Expects an input as a sequence of lines formatted as {@link KeyPair#asString()}.
+ *
+ * <p>Supports inputs in GZIP format, requires ".gz" suffix.
+ */
+public class BlsKeyPairReader {
+
+  private final BufferedReader reader;
+  private int pairsRead = 0;
+
+  public BlsKeyPairReader(BufferedReader reader) {
+    this.reader = reader;
+  }
+
+  public static BlsKeyPairReader createWithDefaultSource() {
+    return createForResource("/bls-key-pairs/bls-pairs-1m-seed_1.gz");
+  }
+
+  public static BlsKeyPairReader createForResource(String resourceName) {
+    try {
+      return createFromStream(ClassLoader.class.getResourceAsStream(resourceName), resourceName);
+    } catch (IOException e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  public static BlsKeyPairReader createForFile(String name) {
+    try {
+      return createFromStream(new FileInputStream(new File(name)), name);
+    } catch (IOException e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  public static BlsKeyPairReader createFromStream(InputStream input, String name) throws IOException {
+    BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(name.endsWith(".gz") ? new GZIPInputStream(input) : input));
+    return new BlsKeyPairReader(reader);
+  }
+
+  public KeyPair next() {
+    try {
+      String parts = reader.readLine();
+      if (parts == null) {
+        throw new RuntimeException("EOF, key pairs read: " + pairsRead);
+      }
+      int delimiterPos = parts.indexOf(":");
+      if (delimiterPos < 0) {
+        throw new RuntimeException("Invalid input: " + parts);
+      }
+      PrivateKey privateKey =
+          PrivateKey.create(Bytes32.fromHexString(parts.substring(0, delimiterPos)));
+      PublicKey publicKey =
+          PublicKey.createWithoutValidation(
+              Bytes48.fromHexString(parts.substring(delimiterPos + 1)));
+
+      pairsRead += 1;
+      return new KeyPair(publicKey, privateKey);
+    } catch (IOException e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+}

--- a/crypto/src/main/java/org/ethereum/beacon/crypto/util/BlsKeyPairReader.java
+++ b/crypto/src/main/java/org/ethereum/beacon/crypto/util/BlsKeyPairReader.java
@@ -29,6 +29,12 @@ public class BlsKeyPairReader {
     this.reader = reader;
   }
 
+  /**
+   * Instantiates reader with predefined key pair source located in {@code /bls-key-pairs/} resource
+   * folder.
+   *
+   * @return an instance of key pair reader.
+   */
   public static BlsKeyPairReader createWithDefaultSource() {
     return createForResource("/bls-key-pairs/bls-pairs-1m-seed_1.gz");
   }
@@ -49,13 +55,20 @@ public class BlsKeyPairReader {
     }
   }
 
-  public static BlsKeyPairReader createFromStream(InputStream input, String name) throws IOException {
+  public static BlsKeyPairReader createFromStream(InputStream input, String name)
+      throws IOException {
     BufferedReader reader =
         new BufferedReader(
             new InputStreamReader(name.endsWith(".gz") ? new GZIPInputStream(input) : input));
     return new BlsKeyPairReader(reader);
   }
 
+  /**
+   * Fetches next pair from the source.
+   *
+   * @return a key pair.
+   * @throws RuntimeException if any error occurred during interaction with underlying source.
+   */
   public KeyPair next() {
     try {
       String parts = reader.readLine();

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,8 @@ include 'start:simulator'
 include 'start:common'
 // Configuration parser
 include 'start:config'
+// Various CLI tools
+include 'start:tools'
 // Test runners for community tests
 include 'test'
 // Strict types definition

--- a/start/simulator/src/main/java/org/ethereum/beacon/simulator/BenchRunner.java
+++ b/start/simulator/src/main/java/org/ethereum/beacon/simulator/BenchRunner.java
@@ -1,0 +1,41 @@
+package org.ethereum.beacon.simulator;
+
+import org.ethereum.beacon.simulator.BenchmarkLauncher.Builder;
+import org.ethereum.beacon.simulator.command.LogLevel;
+import picocli.CommandLine;
+import picocli.CommandLine.RunLast;
+
+@CommandLine.Command(
+    description = "Beacon chain simulator",
+    name = "benchrunner",
+    version = "benchrunner" + BenchRunner.VERSION,
+    mixinStandardHelpOptions = true)
+public class BenchRunner implements Runnable {
+
+  static final String VERSION = "0.1.0";
+
+  private static final int SUCCESS_EXIT_CODE = 0;
+  private static final int ERROR_EXIT_CODE = 1;
+
+  public static void main(String[] args) {
+    try {
+      CommandLine commandLine = new CommandLine(new BenchRunner());
+      commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+      commandLine.parseWithHandlers(
+          new RunLast().andExit(SUCCESS_EXIT_CODE),
+          CommandLine.defaultExceptionHandler().andExit(ERROR_EXIT_CODE),
+          args);
+    } catch (Exception e) {
+      System.out.println(String.format((char) 27 + "[31m" + "FATAL ERROR: %s", e.getMessage()));
+    }
+  }
+
+  @Override
+  public void run() {
+    new Builder()
+        .withLogLevel(LogLevel.info.toLog4j())
+        .withConfigFromResource("/config/default-simulation-config.yml")
+        .build()
+        .run();
+  }
+}

--- a/start/simulator/src/main/java/org/ethereum/beacon/simulator/BenchmarkLauncher.java
+++ b/start/simulator/src/main/java/org/ethereum/beacon/simulator/BenchmarkLauncher.java
@@ -1,0 +1,499 @@
+package org.ethereum.beacon.simulator;
+
+import java.io.File;
+import java.io.InputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.ethereum.beacon.Launcher;
+import org.ethereum.beacon.chain.observer.ObservableBeaconState;
+import org.ethereum.beacon.chain.storage.impl.MemBeaconChainStorageFactory;
+import org.ethereum.beacon.consensus.BeaconChainSpec;
+import org.ethereum.beacon.consensus.transition.EpochTransitionSummary;
+import org.ethereum.beacon.core.BeaconBlock;
+import org.ethereum.beacon.core.operations.Attestation;
+import org.ethereum.beacon.core.operations.Deposit;
+import org.ethereum.beacon.core.spec.SpecConstants;
+import org.ethereum.beacon.core.state.Eth1Data;
+import org.ethereum.beacon.core.types.SlotNumber;
+import org.ethereum.beacon.core.types.Time;
+import org.ethereum.beacon.core.types.ValidatorIndex;
+import org.ethereum.beacon.crypto.BLS381.KeyPair;
+import org.ethereum.beacon.crypto.BLS381.PrivateKey;
+import org.ethereum.beacon.emulator.config.ConfigBuilder;
+import org.ethereum.beacon.emulator.config.chainspec.SpecBuilder;
+import org.ethereum.beacon.emulator.config.chainspec.SpecData;
+import org.ethereum.beacon.emulator.config.main.MainConfig;
+import org.ethereum.beacon.emulator.config.main.plan.SimulationPlan;
+import org.ethereum.beacon.emulator.config.simulator.PeersConfig;
+import org.ethereum.beacon.pow.DepositContract;
+import org.ethereum.beacon.schedulers.ControlledSchedulers;
+import org.ethereum.beacon.schedulers.LoggerMDCExecutor;
+import org.ethereum.beacon.schedulers.Schedulers;
+import org.ethereum.beacon.schedulers.TimeController;
+import org.ethereum.beacon.schedulers.TimeControllerImpl;
+import org.ethereum.beacon.simulator.util.SimulateUtils;
+import org.ethereum.beacon.util.stats.TimeCollector;
+import org.ethereum.beacon.validator.crypto.BLS381Credentials;
+import org.ethereum.beacon.wire.LocalWireHub;
+import org.ethereum.beacon.wire.WireApi;
+import org.javatuples.Pair;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import tech.pegasys.artemis.ethereum.core.Hash32;
+import tech.pegasys.artemis.util.bytes.Bytes32;
+
+public class BenchmarkLauncher implements Runnable {
+  private static final Logger logger = LogManager.getLogger("simulator");
+  private static final Logger wire = LogManager.getLogger("wire");
+
+  private final MainConfig config;
+  private final SimulationPlan simulationPlan;
+  private final List<PeersConfig> validators;
+  private final List<PeersConfig> observers;
+  private final SpecConstants specConstants;
+  private final BeaconChainSpec spec;
+  private final Level logLevel;
+  private final SpecBuilder specBuilder;
+
+  /**
+   * Creates Simulator launcher with following settings
+   *
+   * @param config configuration and run plan.
+   * @param specBuilder chain specification builder.
+   * @param validators validator peers configuration.
+   * @param observers observer peers configuration.
+   * @param logLevel Log level, Apache log4j type.
+   */
+  public BenchmarkLauncher(
+      MainConfig config,
+      SpecBuilder specBuilder,
+      List<PeersConfig> validators,
+      List<PeersConfig> observers,
+      Level logLevel) {
+    this.config = config;
+    this.simulationPlan = (SimulationPlan) config.getPlan();
+    this.specBuilder = specBuilder;
+    this.specConstants = specBuilder.buildSpecConstants();
+    this.spec = specBuilder.buildSpec();
+    this.validators = validators;
+    this.observers = observers;
+    this.logLevel = logLevel;
+  }
+
+  private void setupLogging() {
+    try (InputStream inputStream = ClassLoader.class.getResourceAsStream("/log4j2.xml")) {
+      ConfigurationSource source = new ConfigurationSource(inputStream);
+      Configurator.initialize(null, source);
+    } catch (Exception e) {
+      throw new RuntimeException("Cannot read log4j default configuration", e);
+    }
+
+    // set logLevel
+    if (logLevel != null) {
+      LoggerContext context =
+          (LoggerContext) LogManager.getContext(false);
+      Configuration config = context.getConfiguration();
+      LoggerConfig loggerConfig = config.getLoggerConfig("simulator");
+      loggerConfig.setLevel(logLevel);
+      context.updateLoggers();
+    }
+  }
+
+  private Pair<List<Deposit>, List<KeyPair>> getValidatorDeposits(Random rnd) {
+    Pair<List<Deposit>, List<KeyPair>> deposits =
+        SimulateUtils.getAnyDeposits(rnd, spec, validators.size(),
+            config.getChainSpec().getSpecHelpersOptions().isBlsVerifyProofOfPossession());
+    for (int i = 0; i < validators.size(); i++) {
+      if (validators.get(i).getBlsPrivateKey() != null) {
+        KeyPair keyPair = KeyPair.create(
+            PrivateKey.create(Bytes32.fromHexString(validators.get(i).getBlsPrivateKey())));
+        deposits.getValue0().set(i, SimulateUtils.getDepositForKeyPair(rnd, keyPair, spec,
+            config.getChainSpec().getSpecHelpersOptions().isBlsVerifyProofOfPossession()));
+        deposits.getValue1().set(i, keyPair);
+      }
+    }
+
+    return deposits;
+  }
+
+  public void run() {
+    logger.info("Simulation parameters:\n{}", simulationPlan);
+    if (config.getChainSpec().isDefined())
+      logger.info("Overridden beacon chain parameters:\n{}", config.getChainSpec());
+
+    Random rnd = new Random(simulationPlan.getSeed());
+    setupLogging();
+    Pair<List<Deposit>, List<KeyPair>> validatorDeposits = getValidatorDeposits(rnd);
+
+    List<Deposit> deposits = validatorDeposits.getValue0().stream()
+        .filter(Objects::nonNull).collect(Collectors.toList());
+    List<KeyPair> keyPairs = validatorDeposits.getValue1();
+
+    Time genesisTime = Time.of(simulationPlan.getGenesisTime());
+
+    MDCControlledSchedulers controlledSchedulers = new MDCControlledSchedulers();
+    controlledSchedulers.setCurrentTime(genesisTime.getMillis().getValue() + 1000);
+
+    Eth1Data eth1Data = new Eth1Data(Hash32.random(rnd), Hash32.random(rnd));
+
+    LocalWireHub localWireHub =
+        new LocalWireHub(s -> wire.trace(s), controlledSchedulers.createNew("wire"));
+    DepositContract.ChainStart chainStart =
+        new DepositContract.ChainStart(genesisTime, eth1Data, deposits);
+    DepositContract depositContract = new SimpleDepositContract(chainStart);
+
+    List<Launcher> peers = new ArrayList<>();
+
+    logger.info("Creating validators...");
+    TimeCollector proposeTimeCollector = new TimeCollector();
+    for (int i = 0; i < validators.size(); i++) {
+      ControlledSchedulers schedulers =
+          controlledSchedulers.createNew("V" + i, validators.get(i).getSystemTimeShift());
+      WireApi wireApi =
+          localWireHub.createNewPeer(
+              "" + i,
+              validators.get(i).getWireInboundDelay(),
+              validators.get(i).getWireOutboundDelay());
+
+      BLS381Credentials bls;
+      if (keyPairs.get(i) == null) {
+        bls = null;
+      } else {
+        bls = config.getChainSpec().getSpecHelpersOptions().isBlsSign() ?
+            BLS381Credentials.createWithInsecureSigner(keyPairs.get(i)) :
+            BLS381Credentials.createWithDummySigner(keyPairs.get(i));
+      }
+
+      Launcher launcher =
+          new Launcher(
+              specBuilder.buildSpec(),
+              depositContract,
+              Collections.singletonList(bls),
+              wireApi,
+              new MemBeaconChainStorageFactory(),
+              schedulers,
+              proposeTimeCollector);
+
+      peers.add(launcher);
+
+      if ((i + 1) % 100 == 0)
+        logger.info("{} validators created", (i + 1));
+    }
+    logger.info("All validators created");
+
+    logger.info("Creating observer peers...");
+    for (int i = 0; i < observers.size(); i++) {
+      PeersConfig config = observers.get(i);
+      String name = "O" + i;
+      Launcher launcher =
+          new Launcher(
+              specBuilder.buildSpec(),
+              depositContract,
+              null,
+              localWireHub.createNewPeer(
+                  name, config.getWireInboundDelay(), config.getWireOutboundDelay()),
+              new MemBeaconChainStorageFactory(),
+              controlledSchedulers.createNew(name, config.getSystemTimeShift()));
+      peers.add(launcher);
+    }
+
+    Map<Integer, ObservableBeaconState> latestStates = new HashMap<>();
+    for (int i = 0; i < peers.size(); i++) {
+      Launcher launcher = peers.get(i);
+
+      int finalI = i;
+      Flux.from(launcher.getSlotTicker().getTickerStream()).subscribe(slot ->
+          logger.trace("New slot: " + slot.toString(this.specConstants, genesisTime)));
+      Flux.from(launcher.getObservableStateProcessor().getObservableStateStream())
+          .subscribe(os -> {
+            latestStates.put(finalI, os);
+            logger.trace("New observable state: " + os.toString(spec));
+          });
+      Flux.from(launcher.getBeaconChain().getBlockStatesStream())
+          .subscribe(blockState -> logger.trace("Block imported: "
+              + blockState.getBlock().toString(this.specConstants, genesisTime, spec::signed_root)));
+      if (launcher.getValidatorService() != null) {
+        Flux.from(launcher.getValidatorService().getProposedBlocksStream())
+            .subscribe(block -> logger.debug("New block created: "
+                + block.toString(this.specConstants, genesisTime, spec::signed_root)));
+        Flux.from(launcher.getValidatorService().getAttestationsStream())
+            .subscribe(attest -> logger.debug("New attestation created: "
+                + attest.toString(this.specConstants, genesisTime)));
+      }
+    }
+
+    // system observer
+    ControlledSchedulers schedulers = controlledSchedulers.createNew("X");
+    WireApi wireApi = localWireHub.createNewPeer("X");
+
+    Launcher observer =
+        new Launcher(
+            spec,
+            depositContract,
+            null,
+            wireApi,
+            new MemBeaconChainStorageFactory(),
+            schedulers);
+
+    peers.add(observer);
+
+    List<SlotNumber> slots = new ArrayList<>();
+    List<Attestation> attestations = new ArrayList<>();
+    List<BeaconBlock> blocks = new ArrayList<>();
+    List<ObservableBeaconState> states = new ArrayList<>();
+
+    Flux.from(observer.getSlotTicker().getTickerStream()).subscribe(slot -> {
+      slots.add(slot);
+      logger.debug("New slot: " + slot.toString(specConstants, genesisTime));
+    });
+    Flux.from(observer.getObservableStateProcessor().getObservableStateStream())
+        .subscribe(os -> {
+          latestStates.put(peers.size(), os);
+          states.add(os);
+          logger.debug("New observable state: " + os.toString(spec));
+        });
+    Flux.from(observer.getWireApi().inboundAttestationsStream())
+        .publishOn(observer.getSchedulers().reactorEvents())
+        .subscribe(att -> {
+          attestations.add(att);
+          logger.debug("New attestation received: " + att.toStringShort(specConstants));
+        });
+    Flux.from(observer.getBeaconChain().getBlockStatesStream())
+        .subscribe(blockState -> {
+          blocks.add(blockState.getBlock());
+          logger.debug("Block imported: "
+              + blockState.getBlock().toString(specConstants, genesisTime, spec::signed_root));
+        });
+
+    logger.info("Time starts running ...");
+    controlledSchedulers.setCurrentTime(
+        genesisTime.plus(specConstants.getSecondsPerSlot()).getMillis().getValue() - 9);
+    while (true) {
+      controlledSchedulers.addTime(
+          Duration.ofMillis(specConstants.getSecondsPerSlot().getMillis().getValue()));
+
+      if (slots.size() > 1) {
+        logger.warn("More than 1 slot generated: " + slots);
+      }
+      if (slots.isEmpty()) {
+        logger.error("No slots generated");
+      }
+
+      Map<Hash32, List<ObservableBeaconState>> grouping = latestStates.values().stream()
+          .collect(Collectors.groupingBy(s -> spec.hash_tree_root(s.getLatestSlotState())));
+
+      String statesInfo;
+      if (grouping.size() == 1) {
+        statesInfo = "all peers on the state " + grouping.keySet().iterator().next().toStringShort();
+      } else {
+        statesInfo = "peers states differ:  " + grouping.entrySet().stream()
+            .map(e -> e.getKey().toStringShort() + ": " + e.getValue().size() + " peers")
+            .collect(Collectors.joining(", "));
+
+      }
+
+      logger.info("Slot " + slots.get(0).toStringNumber(specConstants)
+          + ", committee: " + spec
+          .get_crosslink_committees_at_slot(states.get(0).getLatestSlotState(), slots.get(0))
+          + ", blocks: " + blocks.size()
+          + ", attestations: " + attestations.size()
+          + ", " + statesInfo);
+
+      ObservableBeaconState latestState = states.get(states.size() - 1);
+      if (latestState.getLatestSlotState().getSlot().increment().modulo(spec.getConstants().getSlotsPerEpoch())
+          .equals(SlotNumber.ZERO)) {
+        ObservableBeaconState preEpochState = latestState;
+        EpochTransitionSummary summary = observer.getExtendedSlotTransition()
+            .applyWithSummary(preEpochState.getLatestSlotState());
+        logger.info("Epoch transition "
+            + spec.get_current_epoch(preEpochState.getLatestSlotState()).toString(specConstants)
+            + "=>"
+            + spec.get_current_epoch(preEpochState.getLatestSlotState()).increment().toString(specConstants)
+            + ": Justified/Finalized epochs: "
+            + summary.getPreState().getCurrentJustifiedEpoch().toString(specConstants)
+            + "/"
+            + summary.getPreState().getFinalizedEpoch().toString(specConstants)
+            + " => "
+            + summary.getPostState().getCurrentJustifiedEpoch().toString(specConstants)
+            + "/"
+            + summary.getPostState().getFinalizedEpoch().toString(specConstants)
+        );
+        logger.info("  Validators rewarded:"
+            + getValidators(" attestations: ", summary.getAttestationRewards())
+            + getValidators(" boundary: ", summary.getBoundaryAttestationRewards())
+            + getValidators(" head: ", summary.getBeaconHeadAttestationRewards())
+            + getValidators(" include distance: ", summary.getInclusionDistanceRewards())
+            + getValidators(" attest inclusion: ", summary.getAttestationInclusionRewards())
+        );
+        logger.info("  Validators penalized:"
+            + getValidators(" attestations: ", summary.getAttestationPenalties())
+            + getValidators(" boundary: ", summary.getBoundaryAttestationPenalties())
+            + getValidators(" head: ", summary.getBeaconHeadAttestationPenalties())
+            + getValidators(" penalized epoch: ", summary.getInitiatedExitPenalties())
+            + getValidators(" no finality: ", summary.getNoFinalityPenalties())
+        );
+      }
+
+      slots.clear();
+      attestations.clear();
+      blocks.clear();
+      states.clear();
+    }
+  }
+
+  private static String getValidators(String info, Map<ValidatorIndex, ?> records) {
+    if (records.isEmpty()) return "";
+    return info + " ["
+        + records.entrySet().stream().map(e -> e.getKey().toString()).collect(Collectors.joining(","))
+        + "]";
+  }
+
+  private static class SimpleDepositContract implements DepositContract {
+    private final ChainStart chainStart;
+
+    public SimpleDepositContract(ChainStart chainStart) {
+      this.chainStart = chainStart;
+    }
+
+    @Override
+    public Publisher<ChainStart> getChainStartMono() {
+      return Mono.just(chainStart);
+    }
+
+    @Override
+    public Publisher<Deposit> getDepositStream() {
+      return Mono.empty();
+    }
+
+    @Override
+    public List<DepositInfo> peekDeposits(
+        int maxCount, Eth1Data fromDepositExclusive, Eth1Data tillDepositInclusive) {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean hasDepositRoot(Hash32 blockHash, Hash32 depositRoot) {
+      return true;
+    }
+
+    @Override
+    public Optional<Eth1Data> getLatestEth1Data() {
+      return Optional.of(chainStart.getEth1Data());
+    }
+
+    @Override
+    public void setDistanceFromHead(long distanceFromHead) {}
+  }
+
+  public static class MDCControlledSchedulers {
+    private DateFormat localTimeFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+
+    private TimeController timeController = new TimeControllerImpl();
+
+    public ControlledSchedulers createNew(String validatorId) {
+      return createNew(validatorId, 0);
+    }
+
+    public ControlledSchedulers createNew(String validatorId, long timeShift) {
+      ControlledSchedulers[] newSched = new ControlledSchedulers[1];
+      LoggerMDCExecutor mdcExecutor = new LoggerMDCExecutor()
+          .add("validatorTime", () -> localTimeFormat.format(new Date(newSched[0].getCurrentTime())))
+          .add("validatorIndex", () -> "" + validatorId);
+      newSched[0] = Schedulers.createControlled(() -> mdcExecutor);
+      newSched[0].getTimeController().setParent(timeController);
+      newSched[0].getTimeController().setTimeShift(timeShift);
+
+      return newSched[0];
+    }
+
+    public void setCurrentTime(long time) {
+      timeController.setTime(time);
+    }
+
+    void addTime(Duration duration) {
+      addTime(duration.toMillis());
+    }
+
+    void addTime(long millis) {
+      setCurrentTime(timeController.getTime() + millis);
+    }
+
+    public long getCurrentTime() {
+      return timeController.getTime();
+    }
+  }
+
+  public static class Builder {
+    private MainConfig config;
+    private Level logLevel = Level.INFO;
+
+    public Builder() {}
+
+    public BenchmarkLauncher build() {
+      assert config != null;
+      SimulationPlan simulationPlan = (SimulationPlan) config.getPlan();
+
+      ConfigBuilder<SpecData> specConfigBuilder =
+          new ConfigBuilder<>(SpecData.class).addYamlConfigFromResources("/config/spec-constants.yml");
+      if (config.getChainSpec().isDefined()) {
+        specConfigBuilder.addConfig(config.getChainSpec());
+      }
+
+      SpecData spec = specConfigBuilder.build();
+
+      List<PeersConfig> peers = new ArrayList<>();
+      for (PeersConfig peer : simulationPlan.getPeers()) {
+        for (int i = 0; i < peer.getCount(); i++) {
+          peers.add(peer);
+        }
+      }
+
+      SpecBuilder specBuilder = new SpecBuilder().withSpec(spec);
+
+      return new BenchmarkLauncher(
+          config,
+          specBuilder,
+          peers.stream().filter(PeersConfig::isValidator).collect(Collectors.toList()),
+          peers.stream().filter(config -> !config.isValidator()).collect(Collectors.toList()),
+          logLevel);
+    }
+
+    public Builder withConfigFromFile(File file) {
+      this.config = new ConfigBuilder<>(MainConfig.class).addYamlConfig(file).build();
+      return this;
+    }
+
+    public Builder withConfigFromResource(String resourceName) {
+      this.config =
+          new ConfigBuilder<>(MainConfig.class)
+              .addYamlConfigFromResources(resourceName)
+              .build();
+      return this;
+    }
+
+    public Builder withLogLevel(Level logLevel) {
+      this.logLevel = logLevel;
+      return this;
+    }
+  }
+}

--- a/start/tools/build.gradle
+++ b/start/tools/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'application'
+}
+
+// The next two lines disable the tasks for the primary main which by default
+// generates a script with a name matching the project name.
+// You can leave them enabled but if so you'll need to define mainClassName
+// And you'll be creating your application scripts two different ways which
+// could lead to confusion
+startScripts.enabled = false
+run.enabled = false
+
+// Call this for each Main class you want to expose with an app script
+createScript(project, 'org.ethereum.beacon.tools.bls.BlsKeyPairGeneratorTool', 'bls-generator')
+
+dependencies {
+  implementation project(':types')
+  implementation project(':crypto')
+
+  implementation 'info.picocli:picocli'
+}

--- a/start/tools/src/main/java/org/ethereum/beacon/tools/bls/BlsKeyPairGeneratorTool.java
+++ b/start/tools/src/main/java/org/ethereum/beacon/tools/bls/BlsKeyPairGeneratorTool.java
@@ -1,0 +1,54 @@
+package org.ethereum.beacon.tools.bls;
+
+import org.ethereum.beacon.crypto.BLS381.KeyPair;
+import org.ethereum.beacon.crypto.util.BlsKeyPairGenerator;
+import picocli.CommandLine;
+import picocli.CommandLine.RunLast;
+
+@CommandLine.Command(
+    description = "BLS12-381 key pair generator",
+    name = "bls-generator",
+    version = "bls-generator 0.1",
+    mixinStandardHelpOptions = true)
+public class BlsKeyPairGeneratorTool implements Runnable {
+
+  @CommandLine.Option(
+      names = {"--seed"},
+      paramLabel = "value",
+      description = "Integer value that is used as a seed.\nRandom seed is used if not specified.")
+  private Long seed;
+
+  @CommandLine.Option(
+      names = {"--count"},
+      paramLabel = "count",
+      description = "Number of key pairs to be generated.\n16 by default.",
+      defaultValue = "16")
+  private Long count;
+
+  private static final int SUCCESS_EXIT_CODE = 0;
+  private static final int ERROR_EXIT_CODE = 1;
+
+  public static void main(String[] args) {
+    try {
+      CommandLine commandLine = new CommandLine(new BlsKeyPairGeneratorTool());
+      commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+      commandLine.parseWithHandlers(
+          new RunLast().andExit(SUCCESS_EXIT_CODE),
+          CommandLine.defaultExceptionHandler().andExit(ERROR_EXIT_CODE),
+          args);
+    } catch (Exception e) {
+      System.out.println(String.format((char) 27 + "[31m" + "FATAL ERROR: %s", e.getMessage()));
+    }
+  }
+
+  @Override
+  public void run() {
+    BlsKeyPairGenerator generator =
+        seed == null ? BlsKeyPairGenerator.createWithoutSeed() : BlsKeyPairGenerator.create(seed);
+
+    for (long i = 0; i < count; i++) {
+      KeyPair keyPair = generator.next();
+      System.out.println(keyPair.asString());
+    }
+  }
+}


### PR DESCRIPTION
### What was done?
It's been a new CLI tool developed. This tool outputs specified number of random BLS12-381 key pairs that are generated with given seed. It, also, adds a class to read such key pairs from a file or resource and a resource `bls-key-pairts-1m-seed_1.gz` (in a submodule). This resource file contains a million of key pairs generated with `seed = 1`.

Usage:
- use `BlsKeyPairReader reader = BlsKeyPairReader.createWithDefaultSource()` to instantiate a reader with default `bls-key-pairts-1m-seed_1.gz` file
- call `KeyPair keyPair = reader.next()` to fetch next key pair from the source

### Rationale
For those cases where security is not needed, e.g. tests, this change gives a tremendous speed up in obtaining next BLS key pair wrt generating it on the fly: _0.005ms_ vs _5ms_ per pair.