### PR TITLE
Speed up tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,12 +46,6 @@ allprojects {
     }
   }
 
-  tasks.withType(Test) {
-    if (!['wire'].contains(project.name)) { // some tests in `wire` listen dedicated ports
-      maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    }
-  }
-
   javadoc {
     options.author = true
     options.header = project.name

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ allprojects {
     }
   }
 
+  tasks.withType(Test) {
+    if (!['wire'].contains(project.name)) { // some tests in `wire` listen dedicated ports
+      maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
+  }
+
   javadoc {
     options.author = true
     options.header = project.name

--- a/test/src/test/java/org/ethereum/beacon/test/SszTests.java
+++ b/test/src/test/java/org/ethereum/beacon/test/SszTests.java
@@ -34,7 +34,7 @@ public class SszTests extends TestUtils {
           SszStaticRunner testRunner = new SszStaticRunner(input.getValue0(), input.getValue1());
           return testRunner.run();
         },
-        getRecommendedThreadCount() // run it in parallel, a lot of tests
+        true // run it in parallel, a lot of tests
         );
   }
 }

--- a/test/src/test/java/org/ethereum/beacon/test/SszTests.java
+++ b/test/src/test/java/org/ethereum/beacon/test/SszTests.java
@@ -33,6 +33,8 @@ public class SszTests extends TestUtils {
         input -> {
           SszStaticRunner testRunner = new SszStaticRunner(input.getValue0(), input.getValue1());
           return testRunner.run();
-        });
+        },
+        getRecommendedThreadCount() // run it in parallel, a lot of tests
+        );
   }
 }


### PR DESCRIPTION
Following attempts were done and measured to speed up tests execution:

1. gradle default, starting point: `7m 58s`
2. gradle #threads parallel: `7m 50s`
3. gradle #cores parallel: `7m 45s`
4. gradle #cores parallel + sszTests #cores parallel: `5m 6s`
5. gradle #cores parallel + sszTests (#cores - 1) parallel : `5m 38s`
6. default gradle, sszTests #cores parallel: `5m 2s`
7. default gradle, sszTests (#threads - 1) parallel: `4m 54s`

Gradle parallel test execution is a bit tricky in skipping `wire` submodule and may be other modules in future, however it doesn't provide any sensible improvement in execution time, maybe because it runs only module by module in parallel (waiting for all tests in module are completed) or, maybe, by another reason. So, I decided to apply only sszTests parallel running with  number of threads = number of cores (6).
@mkalinin, what do you think?