### PR TITLE
Schedulers old duties

### DIFF
--- a/chain/src/main/java/org/ethereum/beacon/chain/DefaultBeaconChain.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/DefaultBeaconChain.java
@@ -60,7 +60,7 @@ public class DefaultBeaconChain implements MutableBeaconChain {
     this.tupleStorage = chainStorage.getTupleStorage();
     this.schedulers = schedulers;
 
-    blockStream = new SimpleProcessor<>(schedulers.reactorEvents(), "DefaultBeaconChain.block");
+    blockStream = new SimpleProcessor<>(schedulers.events(), "DefaultBeaconChain.block");
   }
 
   @Override

--- a/chain/src/main/java/org/ethereum/beacon/chain/ProposedBlockProcessorImpl.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/ProposedBlockProcessorImpl.java
@@ -16,7 +16,7 @@ public class ProposedBlockProcessorImpl implements ProposedBlockProcessor {
 
   public ProposedBlockProcessorImpl(MutableBeaconChain beaconChain, Schedulers schedulers) {
     this.beaconChain = beaconChain;
-    blocksStream = new SimpleProcessor<>(schedulers.reactorEvents(), "ProposedBlocksProcessor.blocks");
+    blocksStream = new SimpleProcessor<>(schedulers.events(), "ProposedBlocksProcessor.blocks");
   }
 
   @Override

--- a/chain/src/main/java/org/ethereum/beacon/chain/SlotTicker.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/SlotTicker.java
@@ -33,7 +33,7 @@ public class SlotTicker implements Ticker<SlotNumber> {
     this.state = state;
     this.schedulers = schedulers;
 
-    slotStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "SlotTicker.slot");
+    slotStream = new SimpleProcessor<>(this.schedulers.events(), "SlotTicker.slot");
   }
 
   /** Execute to start {@link SlotNumber} propagation */
@@ -58,7 +58,7 @@ public class SlotTicker implements Ticker<SlotNumber> {
     Flux.interval(
             Duration.ofMillis(delayMillis),
             Duration.ofSeconds(period.getValue()),
-            schedulers.reactorEvents())
+            schedulers.events().toReactor())
         .subscribe(tick -> slotStream.onNext(this.startSlot.plus(tick)));
   }
 

--- a/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorImpl.java
+++ b/chain/src/main/java/org/ethereum/beacon/chain/observer/ObservableStateProcessorImpl.java
@@ -109,9 +109,9 @@ public class ObservableStateProcessorImpl implements ObservableStateProcessor {
     this.schedulers = schedulers;
     this.maxEmptySlotTransitions = maxEmptySlotTransitions;
 
-    headStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "ObservableStateProcessor.head");
-    observableStateStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "ObservableStateProcessor.observableState");
-    pendingOperationsStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "PendingOperationsProcessor.pendingOperations");
+    headStream = new SimpleProcessor<>(this.schedulers.events(), "ObservableStateProcessor.head");
+    observableStateStream = new SimpleProcessor<>(this.schedulers.events(), "ObservableStateProcessor.observableState");
+    pendingOperationsStream = new SimpleProcessor<>(this.schedulers.events(), "PendingOperationsProcessor.pendingOperations");
   }
 
   @Override

--- a/pow/core/src/main/java/org/ethereum/beacon/pow/AbstractDepositContract.java
+++ b/pow/core/src/main/java/org/ethereum/beacon/pow/AbstractDepositContract.java
@@ -46,10 +46,10 @@ public abstract class AbstractDepositContract implements DepositContract {
 
     chainStartStream =
         chainStartSink
-            .publishOn(this.schedulers.reactorEvents())
+            .publishOn(this.schedulers.events().toReactor())
             .doOnSubscribe(s -> chainStartSubscribedPriv())
             .name("PowClient.chainStart");
-    depositStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "PowClient.deposit");
+    depositStream = new SimpleProcessor<>(this.schedulers.events(), "PowClient.deposit");
     this.tree = new DepositBufferedMerkle(hashFunction, treeDepth, 1000);
   }
 

--- a/start/benchmaker/src/main/java/org/ethereum/beacon/benchmaker/BenchmarkRunner.java
+++ b/start/benchmaker/src/main/java/org/ethereum/beacon/benchmaker/BenchmarkRunner.java
@@ -13,13 +13,11 @@ import org.ethereum.beacon.bench.BenchmarkReport;
 import org.ethereum.beacon.bench.BenchmarkUtils;
 import org.ethereum.beacon.chain.storage.impl.MemBeaconChainStorageFactory;
 import org.ethereum.beacon.consensus.BeaconChainSpec;
-import org.ethereum.beacon.consensus.BeaconChainSpec.Builder;
 import org.ethereum.beacon.consensus.util.CachingBeaconChainSpec;
 import org.ethereum.beacon.core.BeaconBlock;
 import org.ethereum.beacon.core.operations.Attestation;
 import org.ethereum.beacon.core.operations.Deposit;
 import org.ethereum.beacon.core.state.Eth1Data;
-import org.ethereum.beacon.core.types.EpochNumber;
 import org.ethereum.beacon.core.types.SlotNumber;
 import org.ethereum.beacon.core.types.Time;
 import org.ethereum.beacon.crypto.BLS381;
@@ -136,7 +134,7 @@ public class BenchmarkRunner implements Runnable {
 
     Flux.from(instance.getSlotTicker().getTickerStream()).subscribe(slots::add);
     Flux.from(instance.getValidatorService().getAttestationsStream())
-        .publishOn(instance.getSchedulers().reactorEvents())
+        .publishOn(instance.getSchedulers().events().toReactor())
         .subscribe(attestations::add);
     Flux.from(instance.getBeaconChain().getBlockStatesStream())
         .subscribe(blockState -> blocks.add(blockState.getBlock()));

--- a/start/common/src/main/java/org/ethereum/beacon/start/common/Launcher.java
+++ b/start/common/src/main/java/org/ethereum/beacon/start/common/Launcher.java
@@ -148,7 +148,7 @@ public class Launcher {
 
     DirectProcessor<Attestation> allAttestations = DirectProcessor.create();
     Flux.from(wireApi.inboundAttestationsStream())
-        .publishOn(schedulers.reactorEvents())
+        .publishOn(schedulers.events().toReactor())
         .subscribe(allAttestations);
 
     observableStateProcessor = new ObservableStateProcessorImpl(
@@ -186,7 +186,7 @@ public class Launcher {
     }
 
     Flux.from(wireApi.inboundBlocksStream())
-        .publishOn(schedulers.reactorEvents())
+        .publishOn(schedulers.events().toReactor())
         .subscribe(beaconChain::insert);
   }
 

--- a/start/common/src/main/java/org/ethereum/beacon/start/common/NodeLauncher.java
+++ b/start/common/src/main/java/org/ethereum/beacon/start/common/NodeLauncher.java
@@ -210,7 +210,7 @@ public class NodeLauncher {
     }
 
     Flux.from(wireApiSub.inboundAttestationsStream())
-        .publishOn(schedulers.reactorEvents())
+        .publishOn(schedulers.events().toReactor())
         .subscribe(allAttestations);
 
     Flux<BeaconBlock> allNewBlocks = Flux.merge(ownBlocks, wireApiSub.inboundBlocksStream());
@@ -222,7 +222,7 @@ public class NodeLauncher {
         wireApiSyncRemote,
         syncQueue,
         1,
-        schedulers.reactorEvents());
+        schedulers.events());
     syncManager.setRequestsDelay(Duration.ofSeconds(1), Duration.ofSeconds(5));
 
     if (startSyncManager) {

--- a/start/node/src/main/java/org/ethereum/beacon/node/NodeCommandLauncher.java
+++ b/start/node/src/main/java/org/ethereum/beacon/node/NodeCommandLauncher.java
@@ -160,7 +160,7 @@ public class NodeCommandLauncher implements Runnable {
       Scheduler clientScheduler = schedulers.newParallelDaemon("netty-client-%d", 2);
       NettyClient nettyClient = new NettyClient(clientScheduler::executeR);
       ConnectionManager<SocketAddress> tcpConnectionManager =
-          new ConnectionManager<>(nettyServer, nettyClient, schedulers.reactorEvents());
+          new ConnectionManager<>(nettyServer, nettyClient, schedulers.events());
       connectionManager = tcpConnectionManager;
       for (String addr : nettyConfig.getActivePeers()) {
         URI uri = URI.create(addr);

--- a/start/simulator/src/main/java/org/ethereum/beacon/simulator/SimulatorLauncher.java
+++ b/start/simulator/src/main/java/org/ethereum/beacon/simulator/SimulatorLauncher.java
@@ -260,7 +260,7 @@ public class SimulatorLauncher implements Runnable {
           logger.debug("New observable state: " + os.toString(spec));
         });
     Flux.from(observer.getWireApi().inboundAttestationsStream())
-        .publishOn(observer.getSchedulers().reactorEvents())
+        .publishOn(observer.getSchedulers().events().toReactor())
         .subscribe(att -> {
           attestations.add(att);
           logger.debug("New attestation received: " + att.toStringShort(specConstants));

--- a/util/src/main/java/org/ethereum/beacon/schedulers/AbstractSchedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/AbstractSchedulers.java
@@ -25,7 +25,7 @@ public abstract class AbstractSchedulers implements Schedulers {
   protected abstract ScheduledExecutorService createExecutor(String namePattern, int threads);
 
   protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
-    return new ExecutorScheduler(executorService);
+    return new ExecutorScheduler(executorService, this::getCurrentTime);
   }
 
   @Override
@@ -89,22 +89,6 @@ public abstract class AbstractSchedulers implements Schedulers {
       eventsExecutor = createExecutor("Schedulers-events", 1);
     }
     return eventsExecutor;
-  }
-
-  @Override
-  public reactor.core.scheduler.Scheduler reactorEvents() {
-    if (eventsReactorScheduler == null) {
-      synchronized (this) {
-        if (eventsReactorScheduler == null) {
-          eventsReactorScheduler = createReactorEvents();
-        }
-      }
-    }
-    return eventsReactorScheduler;
-  }
-
-  protected reactor.core.scheduler.Scheduler createReactorEvents() {
-    return reactor.core.scheduler.Schedulers.fromExecutor(getEventsExecutor());
   }
 
   @Override

--- a/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulersImpl.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/ControlledSchedulersImpl.java
@@ -19,7 +19,8 @@ public class ControlledSchedulersImpl extends AbstractSchedulers implements Cont
 
   @Override
   protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
-    return new ErrorHandlingScheduler(new ExecutorScheduler(executorService), e -> e.printStackTrace());
+    return new ErrorHandlingScheduler(
+        new ExecutorScheduler(executorService, this::getCurrentTime), e -> e.printStackTrace());
   }
 
   @Override

--- a/util/src/main/java/org/ethereum/beacon/schedulers/DefaultSchedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/DefaultSchedulers.java
@@ -24,7 +24,8 @@ public class DefaultSchedulers extends AbstractSchedulers {
 
   @Override
   protected Scheduler createExecutorScheduler(ScheduledExecutorService executorService) {
-    return new ErrorHandlingScheduler(new ExecutorScheduler(executorService), errorHandler);
+    return new ErrorHandlingScheduler(
+        new ExecutorScheduler(executorService, this::getCurrentTime), errorHandler);
   }
 
   @Override

--- a/util/src/main/java/org/ethereum/beacon/schedulers/DelegatingReactorScheduler.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/DelegatingReactorScheduler.java
@@ -1,0 +1,101 @@
+package org.ethereum.beacon.schedulers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import reactor.core.Disposable;
+import reactor.core.scheduler.Scheduler;
+
+public class DelegatingReactorScheduler implements reactor.core.scheduler.Scheduler {
+
+  protected final reactor.core.scheduler.Scheduler delegate;
+  protected final Supplier<Long> timeSupplier;
+
+  public DelegatingReactorScheduler(Scheduler delegate, Supplier<Long> timeSupplier) {
+    this.delegate = delegate;
+    this.timeSupplier = timeSupplier;
+  }
+
+  @Nonnull
+  @Override
+  public Disposable schedule(@Nonnull Runnable task) {
+    return delegate.schedule(task);
+  }
+
+  @Nonnull
+  @Override
+  public Disposable schedule(Runnable task, long delay,
+      TimeUnit unit) {
+    return delegate.schedule(task, delay, unit);
+  }
+
+  @Nonnull
+  @Override
+  public Disposable schedulePeriodically(Runnable task, long initialDelay, long period,
+      TimeUnit unit) {
+    return delegate.schedulePeriodically(task, initialDelay, period, unit);
+  }
+
+  @Override
+  public long now(TimeUnit unit) {
+    return unit.convert(timeSupplier.get(), TimeUnit.MILLISECONDS);
+  }
+
+  @Nonnull
+  @Override
+  public Worker createWorker() {
+    return delegate.createWorker();
+  }
+
+  @Override
+  public void dispose() {
+    delegate.dispose();
+  }
+
+  @Override
+  public void start() {
+    delegate.start();
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return delegate.isDisposed();
+  }
+
+  public static class DelegateWorker implements Worker {
+    protected final Worker delegate;
+
+    public DelegateWorker(Worker delegate) {
+      this.delegate = delegate;
+    }
+
+    @Nonnull
+    @Override
+    public Disposable schedule(@Nonnull Runnable task) {
+      return delegate.schedule(task);
+    }
+
+    @Nonnull
+    @Override
+    public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+      return delegate.schedule(task, delay, unit);
+    }
+
+    @Nonnull
+    @Override
+    public Disposable schedulePeriodically(Runnable task, long initialDelay, long period,
+        TimeUnit unit) {
+      return delegate.schedulePeriodically(task, initialDelay, period, unit);
+    }
+
+    @Override
+    public void dispose() {
+      delegate.dispose();
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return delegate.isDisposed();
+    }
+  }
+}

--- a/util/src/main/java/org/ethereum/beacon/schedulers/Schedulers.java
+++ b/util/src/main/java/org/ethereum/beacon/schedulers/Schedulers.java
@@ -73,12 +73,6 @@ public interface Schedulers {
   Scheduler events();
 
   /**
-   * Reactor Scheduler decorator for {@link #events()} Scheduler. Those two shares the
-   * same thread/pool
-   */
-  reactor.core.scheduler.Scheduler reactorEvents();
-
-  /**
    * Creates new single thread Scheduler with the specified thread name
    */
   default Scheduler newSingleThreadDaemon(String threadName) {

--- a/util/src/main/java/org/ethereum/beacon/stream/SimpleProcessor.java
+++ b/util/src/main/java/org/ethereum/beacon/stream/SimpleProcessor.java
@@ -1,5 +1,6 @@
 package org.ethereum.beacon.stream;
 
+import org.ethereum.beacon.schedulers.Scheduler;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -7,7 +8,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxProcessor;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.ReplayProcessor;
-import reactor.core.scheduler.Scheduler;
 
 public class SimpleProcessor<T> implements Processor<T, T> {
   FluxProcessor<T, T> subscriber;
@@ -16,6 +16,10 @@ public class SimpleProcessor<T> implements Processor<T, T> {
   boolean subscribed;
 
   public SimpleProcessor(Scheduler scheduler, String name) {
+    this(scheduler.toReactor(), name);
+  }
+
+  public SimpleProcessor(reactor.core.scheduler.Scheduler scheduler, String name) {
     ReplayProcessor<T> processor = ReplayProcessor.cacheLast();
     subscriber = processor;
     sink = subscriber.sink();

--- a/util/src/test/java/org/ethereum/beacon/schedulers/LatestExecutorTest.java
+++ b/util/src/test/java/org/ethereum/beacon/schedulers/LatestExecutorTest.java
@@ -29,7 +29,7 @@ public class LatestExecutorTest {
         return super.decorateTask(callable, task);
       }
     };
-    ExecutorScheduler scheduler = new ExecutorScheduler(executor);
+    ExecutorScheduler scheduler = new ExecutorScheduler(executor, System::currentTimeMillis);
 
     List<Integer> processedEvents = new ArrayList<>();
     LatestExecutor<Integer> latestExecutor = new LatestExecutor<>(scheduler, i -> {

--- a/validator/src/main/java/org/ethereum/beacon/validator/MultiValidatorService.java
+++ b/validator/src/main/java/org/ethereum/beacon/validator/MultiValidatorService.java
@@ -87,9 +87,9 @@ public class MultiValidatorService implements ValidatorService {
     this.stateStream = stateStream;
     this.schedulers = schedulers;
 
-    blocksStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "BeaconChainValidator.block");
-    attestationsStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "BeaconChainValidator.attestation");
-    initializedStream = new SimpleProcessor<>(this.schedulers.reactorEvents(), "BeaconChainValidator.init");
+    blocksStream = new SimpleProcessor<>(this.schedulers.events(), "BeaconChainValidator.block");
+    attestationsStream = new SimpleProcessor<>(this.schedulers.events(), "BeaconChainValidator.attestation");
+    initializedStream = new SimpleProcessor<>(this.schedulers.events(), "BeaconChainValidator.init");
 
     executor = this.schedulers.newSingleThreadDaemon("validator-service");
     initExecutor = new LatestExecutor<>(schedulers.blocking(), this::initFromLatestBeaconState);

--- a/wire/src/main/java/org/ethereum/beacon/wire/LocalWireHub.java
+++ b/wire/src/main/java/org/ethereum/beacon/wire/LocalWireHub.java
@@ -71,7 +71,7 @@ public class LocalWireHub {
         return blocks;
       } else {
         return Flux.from(blocks)
-            .delayElements(Duration.ofMillis(inboundDelay), schedulers.reactorEvents());
+            .delayElements(Duration.ofMillis(inboundDelay), schedulers.events().toReactor());
       }
     }
 
@@ -81,7 +81,7 @@ public class LocalWireHub {
         return attestations;
       } else {
         return Flux.from(attestations)
-            .delayElements(Duration.ofMillis(inboundDelay), schedulers.reactorEvents());
+            .delayElements(Duration.ofMillis(inboundDelay), schedulers.events().toReactor());
       }
     }
   }

--- a/wire/src/main/java/org/ethereum/beacon/wire/net/ConnectionManager.java
+++ b/wire/src/main/java/org/ethereum/beacon/wire/net/ConnectionManager.java
@@ -9,13 +9,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.schedulers.Scheduler;
 import org.ethereum.beacon.wire.channel.Channel;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.ReplayProcessor;
-import reactor.core.scheduler.Scheduler;
 import tech.pegasys.artemis.util.bytes.BytesValue;
 
 public class ConnectionManager<TAddress> {
@@ -71,7 +71,7 @@ public class ConnectionManager<TAddress> {
           activePeerConnections.remove(peerAddress);
           logger.info("Disconnected from active peer " + peerAddress);
         })
-        .delayElements(Duration.ofSeconds(RECONNECT_TIMEOUT_SECONDS), rxScheduler)
+        .delayElements(Duration.ofSeconds(RECONNECT_TIMEOUT_SECONDS), rxScheduler.toReactor())
         .repeat(() -> activePeers.contains(peerAddress))
         .subscribe();
   }

--- a/wire/src/test/java/org/ethereum/beacon/wire/NodeTest.java
+++ b/wire/src/test/java/org/ethereum/beacon/wire/NodeTest.java
@@ -84,7 +84,7 @@ public class NodeTest {
         ControlledSchedulers schedulers = controlledSchedulers.createNew("master");
         nettyServer.start();
         ConnectionManager<SocketAddress> connectionManager = new ConnectionManager<>(
-            nettyServer, null, schedulers.reactorEvents());
+            nettyServer, null, schedulers.events());
         masterNode = new NodeLauncher(
             specBuilder.buildSpec(),
             depositContract,
@@ -110,7 +110,7 @@ public class NodeTest {
         ControlledSchedulers schedulers = controlledSchedulers.createNew("slave");
         NettyClient nettyClient = new NettyClient();
         slaveConnectionManager = new ConnectionManager<>(
-            null, nettyClient, schedulers.reactorEvents());
+            null, nettyClient, schedulers.events());
         slaveNode = new NodeLauncher(
             specBuilder.buildSpec(),
             depositContract,

--- a/wire/src/test/java/org/ethereum/beacon/wire/PeersTest.java
+++ b/wire/src/test/java/org/ethereum/beacon/wire/PeersTest.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.ethereum.beacon.schedulers.Schedulers;
 import org.ethereum.beacon.start.common.Launcher;
 import org.ethereum.beacon.simulator.SimulatorLauncher;
 import org.ethereum.beacon.simulator.SimulatorLauncher.Builder;
@@ -28,7 +29,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.ReplayProcessor;
-import reactor.core.scheduler.Schedulers;
 import tech.pegasys.artemis.util.bytes.BytesValue;
 import tech.pegasys.artemis.util.uint.UInt64;
 
@@ -36,7 +36,7 @@ public class PeersTest {
 
   @Test
   public void test0() {
-    SimpleProcessor<Integer> processor = new SimpleProcessor<>(Schedulers.single(), "aaa");
+    SimpleProcessor<Integer> processor = new SimpleProcessor<>(Schedulers.createDefault().events(), "aaa");
     processor.onNext(1);
     Integer i = Mono.from(processor).block(Duration.ofMillis(300));
     System.out.println(i);
@@ -81,7 +81,7 @@ public class PeersTest {
         server.start().await();
         System.out.println("Peer 0 listening on port 40001");
         ConnectionManager<SocketAddress> connectionManager = new ConnectionManager<>(
-            server, null, Schedulers.single());
+            server, null, Schedulers.createDefault().events());
 
         SSZSerializer ssz = new SSZBuilder().buildSerializer();
         MessageSerializer messageSerializer = new SSZMessageSerializer(ssz);
@@ -117,7 +117,7 @@ public class PeersTest {
       {
         // peer 1
         ConnectionManager<SocketAddress> connectionManager = new ConnectionManager<>(
-            null, new NettyClient(), Schedulers.single());
+            null, new NettyClient(), Schedulers.createDefault().events());
 
         SSZSerializer ssz = new SSZBuilder().buildSerializer();
         MessageSerializer messageSerializer = new SSZMessageSerializer(ssz);
@@ -151,7 +151,7 @@ public class PeersTest {
             peerManager.getWireApiSync(),
             syncQueue,
             1,
-            peer1.getSchedulers().reactorEvents());
+            peer1.getSchedulers().events());
 
         CountDownLatch syncLatch = new CountDownLatch(1);
         Flux.from(peer1.getBeaconChain().getBlockStatesStream())

--- a/wire/src/test/java/org/ethereum/beacon/wire/net/ConnectionManagerTest.java
+++ b/wire/src/test/java/org/ethereum/beacon/wire/net/ConnectionManagerTest.java
@@ -53,7 +53,7 @@ public class ConnectionManagerTest {
     TestClient client = new TestClient();
     ControlledSchedulers schedulers = Schedulers.createControlled();
     ConnectionManager<String> manager = new ConnectionManager<>(null, client,
-        schedulers.reactorEvents());
+        schedulers.events());
     Flux.from(manager.channelsStream()).subscribe(channels::add);
 
     manager.addActivePeer("1");

--- a/wire/src/test/java/org/ethereum/beacon/wire/sync/SyncTest.java
+++ b/wire/src/test/java/org/ethereum/beacon/wire/sync/SyncTest.java
@@ -84,7 +84,7 @@ public class SyncTest {
         asyncSyncServer,
         syncQueue,
         1,
-        testPeer.getSchedulers().reactorEvents());
+        testPeer.getSchedulers().events());
 
     AtomicBoolean synced = new AtomicBoolean();
     Flux.from(testPeer.getBeaconChain().getBlockStatesStream())


### PR DESCRIPTION
- Add conversion from our Scheduler to Reactor Scheduler. 
- Remove special Reactor method from Schedulers
- Correctly implement Reactor Scheduler.now().
- Fix ErrorHandlingScheduler to handle exceptions on Reactor scheduler as well