### PR TITLE
Refactor method name to distinguish by parameter name

### DIFF
--- a/discovery/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
+++ b/discovery/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
@@ -31,11 +31,6 @@ public class WhoAreYouPacket extends AbstractPacket {
 
   /**
    * Create a packet by converting {@code destNodeId} to a magic value
-   * @param destNodeId
-   * @param authTag
-   * @param idNonce
-   * @param enrSeq
-   * @return
    */
   public static WhoAreYouPacket createFromNodeId(
       Bytes32 destNodeId, BytesValue authTag, Bytes32 idNonce, UInt64 enrSeq) {

--- a/discovery/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
+++ b/discovery/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
@@ -29,13 +29,13 @@ public class WhoAreYouPacket extends AbstractPacket {
     super(bytes);
   }
 
-  public static WhoAreYouPacket create(
+  public static WhoAreYouPacket createFromNodeId(
       Bytes32 destNodeId, BytesValue authTag, Bytes32 idNonce, UInt64 enrSeq) {
     BytesValue magic = getStartMagic(destNodeId);
-    return create(magic, authTag, idNonce, enrSeq);
+    return createFromMagic(magic, authTag, idNonce, enrSeq);
   }
 
-  public static WhoAreYouPacket create(
+  public static WhoAreYouPacket createFromMagic(
       BytesValue magic, BytesValue authTag, Bytes32 idNonce, UInt64 enrSeq) {
     byte[] rlpListEncoded =
         RlpEncoder.encode(

--- a/discovery/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
+++ b/discovery/src/main/java/org/ethereum/beacon/discovery/packet/WhoAreYouPacket.java
@@ -29,6 +29,14 @@ public class WhoAreYouPacket extends AbstractPacket {
     super(bytes);
   }
 
+  /**
+   * Create a packet by converting {@code destNodeId} to a magic value
+   * @param destNodeId
+   * @param authTag
+   * @param idNonce
+   * @param enrSeq
+   * @return
+   */
   public static WhoAreYouPacket createFromNodeId(
       Bytes32 destNodeId, BytesValue authTag, Bytes32 idNonce, UInt64 enrSeq) {
     BytesValue magic = getStartMagic(destNodeId);

--- a/discovery/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NotExpectedIncomingPacketHandler.java
+++ b/discovery/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NotExpectedIncomingPacketHandler.java
@@ -60,7 +60,7 @@ public class NotExpectedIncomingPacketHandler implements EnvelopeHandler {
       Bytes32 idNonce = Bytes32.wrap(idNonceBytes);
       session.setIdNonce(idNonce);
       WhoAreYouPacket whoAreYouPacket =
-          WhoAreYouPacket.create(
+          WhoAreYouPacket.createFromNodeId(
               session.getNodeRecord().getNodeId(),
               authTag,
               idNonce,

--- a/discovery/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/discovery/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -137,7 +137,7 @@ public class HandshakeHandlersTest {
     authTagRepository1.put(authTag, nodeSessionAt1For2);
     envelopeAt1From2.put(
         Field.PACKET_WHOAREYOU,
-        WhoAreYouPacket.create(nodePair1.getValue1().getNodeId(), authTag, idNonce, UInt64.ZERO));
+        WhoAreYouPacket.createFromNodeId(nodePair1.getValue1().getNodeId(), authTag, idNonce, UInt64.ZERO));
     envelopeAt1From2.put(Field.SESSION, nodeSessionAt1For2);
     CompletableFuture<Void> future = new CompletableFuture<>();
     nodeSessionAt1For2.createNextRequest(TaskType.FINDNODE, new TaskOptions(true), future);

--- a/discovery/src/test/java/org/ethereum/beacon/discovery/community/PacketEncodingTest.java
+++ b/discovery/src/test/java/org/ethereum/beacon/discovery/community/PacketEncodingTest.java
@@ -30,7 +30,7 @@ public class PacketEncodingTest {
   @Test
   public void encodeWhoAreYouTest() {
     WhoAreYouPacket whoAreYouPacket =
-        WhoAreYouPacket.create(
+        WhoAreYouPacket.createFromMagic(
             BytesValue.fromHexString(
                 "0x0101010101010101010101010101010101010101010101010101010101010101"),
             BytesValue.fromHexString("0x020202020202020202020202"),


### PR DESCRIPTION
This refactor is to make it clearer when magic is applied to the first parameter in `WhoAreYouPacket`. For both `create` methods, I thought the `Bytes` and `Bytes32` types of the first parameter were too closely related, making it hard for me to distinguish when generalizing types (integration of this discv5 into Artemis uses Tuweni `Bytes`). 